### PR TITLE
Feature: Add reservation fee notice and improve public reservation flow

### DIFF
--- a/src/components/PublicReservationFlow.tsx
+++ b/src/components/PublicReservationFlow.tsx
@@ -43,7 +43,9 @@ export default function PublicReservationFlow({
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && isOpen) {
-        handleClose();
+        setStep('phone');
+        setPhone('');
+        onClose();
       }
     };
 
@@ -51,7 +53,7 @@ export default function PublicReservationFlow({
       document.addEventListener('keydown', handleEscape);
       return () => document.removeEventListener('keydown', handleEscape);
     }
-  }, [isOpen]);
+  }, [isOpen, onClose]);
 
   // Fetch location display name
   useEffect(() => {
@@ -387,7 +389,7 @@ export default function PublicReservationFlow({
               </p>
               <button
                 onClick={() => {
-                  window.location.href = `sms:${MEMBERSHIP_PHONE}?body=${MEMBERSHIP_SMS_BODY}`;
+                  window.location.href = `sms:${MEMBERSHIP_PHONE}?body=${encodeURIComponent(MEMBERSHIP_SMS_BODY)}`;
                 }}
                 style={{
                   width: '100%',

--- a/src/components/PublicReservationFlow.tsx
+++ b/src/components/PublicReservationFlow.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { X } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
+import { supabase } from '@/lib/supabase';
 import SimpleReservationRequestModal from './member/SimpleReservationRequestModal';
 
 interface Props {
@@ -19,10 +20,30 @@ export default function PublicReservationFlow({
   onReservationCreated,
 }: Props) {
   const { toast } = useToast();
-  const [step, setStep] = useState<'phone' | 'reservation'>('phone');
+  const [step, setStep] = useState<'phone' | 'fee-notice' | 'reservation'>('phone');
   const [phone, setPhone] = useState('');
   const [isCheckingPhone, setIsCheckingPhone] = useState(false);
   const [memberData, setMemberData] = useState<any>(null);
+  const [locationName, setLocationName] = useState<string>(locationSlug);
+
+  // Fetch location display name
+  useEffect(() => {
+    const fetchLocationName = async () => {
+      const { data, error } = await supabase
+        .from('locations')
+        .select('name')
+        .eq('slug', locationSlug)
+        .single();
+
+      if (data && !error) {
+        setLocationName(data.name);
+      }
+    };
+
+    if (isOpen && locationSlug) {
+      fetchLocationName();
+    }
+  }, [isOpen, locationSlug]);
 
   // Format phone number as (XXX)XXX-XXXX
   const formatPhoneNumber = (value: string) => {
@@ -71,8 +92,8 @@ export default function PublicReservationFlow({
           window.location.href = '/member/login';
         }, 2000);
       } else {
-        // Not a member - proceed to reservation form
-        setStep('reservation');
+        // Not a member - show fee notice first
+        setStep('fee-notice');
       }
     } catch (error) {
       console.error('Error checking phone:', error);
@@ -128,9 +149,9 @@ export default function PublicReservationFlow({
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}
-          <div style={{ marginBottom: '1.5rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', color: '#1F1F1F', margin: 0 }}>
-              Make a Reservation
+          <div style={{ marginBottom: '0.5rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <h2 style={{ fontSize: '1.125rem', fontWeight: '600', color: '#1F1F1F', margin: 0 }}>
+              Make a Reservation for {locationName}
             </h2>
             <button
               onClick={handleClose}
@@ -178,6 +199,18 @@ export default function PublicReservationFlow({
                 outline: 'none',
               }}
             />
+
+            {/* SMS Agreement */}
+            <div style={{
+              fontSize: '0.8125rem',
+              color: '#6B7280',
+              textAlign: 'center',
+              lineHeight: '1.5',
+              marginTop: '0.5rem',
+            }}>
+              By requesting this reservation, you agree to receive SMS messages regarding your reservation. Message and data rates may apply. We are not responsible for carrier charges or delivery failures. You can opt out at any time.
+            </div>
+
             <button
               onClick={handlePhoneSubmit}
               disabled={isCheckingPhone}
@@ -203,7 +236,140 @@ export default function PublicReservationFlow({
     );
   }
 
-  // Step 2: Reservation form (non-members only)
+  // Step 2: Fee notice
+  if (step === 'fee-notice') {
+    return (
+      <div
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: 'rgba(0, 0, 0, 0.6)',
+          backdropFilter: 'blur(4px)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 9999,
+          padding: '1rem',
+        }}
+        onClick={handleClose}
+      >
+        <div
+          style={{
+            backgroundColor: '#ECEDE8',
+            borderRadius: '16px',
+            boxShadow: '0 4px 24px rgba(0, 0, 0, 0.15)',
+            maxWidth: '500px',
+            width: '100%',
+            padding: '2rem',
+            position: 'relative',
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div style={{ marginBottom: '1.5rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <h2 style={{ fontSize: '1.125rem', fontWeight: '600', color: '#1F1F1F', margin: 0 }}>
+              Reservation Fee
+            </h2>
+            <button
+              onClick={handleClose}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                padding: '0.5rem',
+                borderRadius: '0.375rem',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#6B7280',
+                transition: 'all 0.2s',
+              }}
+            >
+              <X size={24} />
+            </button>
+          </div>
+
+          {/* Fee Notice */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+            {/* Reservation Fee Section */}
+            <div style={{
+              backgroundColor: 'white',
+              padding: '1.25rem',
+              borderRadius: '10px',
+              border: '1px solid #D1D5DB',
+            }}>
+              <p style={{ fontSize: '0.9375rem', color: '#1F2937', fontWeight: '600', margin: '0 0 0.5rem 0', lineHeight: '1.5', textAlign: 'center' }}>
+                $20/person Reservation Fee
+              </p>
+              <p style={{ fontSize: '0.875rem', color: '#4B5563', margin: '0 0 0.5rem 0', lineHeight: '1.5', textAlign: 'center' }}>
+                (includes first drink)
+              </p>
+              <p style={{ fontSize: '0.75rem', color: '#6B7280', margin: '0 0 1rem 0', lineHeight: '1.4', textAlign: 'center' }}>
+                Non-refundable unless cancelled by RooftopKC
+              </p>
+              <button
+                onClick={() => setStep('reservation')}
+                style={{
+                  width: '100%',
+                  height: '44px',
+                  backgroundColor: '#A59480',
+                  color: 'white',
+                  fontSize: '0.9375rem',
+                  fontWeight: '600',
+                  borderRadius: '10px',
+                  border: 'none',
+                  cursor: 'pointer',
+                  boxShadow: '0 2px 8px rgba(165, 148, 128, 0.2)',
+                  transition: 'background-color 0.2s',
+                }}
+              >
+                Continue with Reservation
+              </button>
+            </div>
+
+            {/* Membership Benefits Section */}
+            <div style={{
+              backgroundColor: '#F9FAFB',
+              padding: '1.25rem',
+              borderRadius: '12px',
+              border: '1px solid #E5E7EB',
+            }}>
+              <p style={{ fontSize: '0.9375rem', color: '#1F2937', fontWeight: '600', margin: '0 0 0.5rem 0', textAlign: 'center' }}>
+                Request Invitation to Noir
+              </p>
+              <p style={{ fontSize: '0.875rem', color: '#4B5563', margin: '0 0 1rem 0', lineHeight: '1.5', textAlign: 'center' }}>
+                No reservation fee + exclusive benefits
+              </p>
+              <button
+                onClick={() => {
+                  window.location.href = 'sms:9137774488?body=MEMBERSHIP';
+                }}
+                style={{
+                  width: '100%',
+                  height: '44px',
+                  backgroundColor: 'white',
+                  color: '#A59480',
+                  fontSize: '0.9375rem',
+                  fontWeight: '600',
+                  borderRadius: '10px',
+                  border: '2px solid #A59480',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s',
+                }}
+              >
+                Request Membership
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Step 3: Reservation form (non-members only)
   return (
     <SimpleReservationRequestModal
       isOpen={true}
@@ -211,6 +377,7 @@ export default function PublicReservationFlow({
       memberPhone={phone}
       locationSlug={locationSlug}
       hideTableSelection={true}
+      onBack={() => setStep('fee-notice')}
       onReservationCreated={() => {
         if (onReservationCreated) {
           onReservationCreated();

--- a/src/components/PublicReservationFlow.tsx
+++ b/src/components/PublicReservationFlow.tsx
@@ -145,7 +145,6 @@ export default function PublicReservationFlow({
   const handleClose = () => {
     setStep('phone');
     setPhone('');
-    setMemberData(null);
     onClose();
   };
 

--- a/src/components/PublicReservationFlow.tsx
+++ b/src/components/PublicReservationFlow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { X } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { supabase } from '@/lib/supabase';
@@ -23,20 +23,55 @@ export default function PublicReservationFlow({
   const [step, setStep] = useState<'phone' | 'fee-notice' | 'reservation'>('phone');
   const [phone, setPhone] = useState('');
   const [isCheckingPhone, setIsCheckingPhone] = useState(false);
-  const [memberData, setMemberData] = useState<any>(null);
   const [locationName, setLocationName] = useState<string>(locationSlug);
+  const redirectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Constants
+  const MEMBERSHIP_PHONE = '9137774488';
+  const MEMBERSHIP_SMS_BODY = 'MEMBERSHIP';
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (redirectTimeoutRef.current) {
+        clearTimeout(redirectTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  // Handle ESC key to close modal
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        handleClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+  }, [isOpen]);
 
   // Fetch location display name
   useEffect(() => {
     const fetchLocationName = async () => {
-      const { data, error } = await supabase
-        .from('locations')
-        .select('name')
-        .eq('slug', locationSlug)
-        .single();
+      try {
+        const { data, error } = await supabase
+          .from('locations')
+          .select('name')
+          .eq('slug', locationSlug)
+          .single();
 
-      if (data && !error) {
-        setLocationName(data.name);
+        if (data && !error) {
+          setLocationName(data.name);
+        } else if (error) {
+          console.error('Error fetching location name:', error);
+          // Keep using slug as fallback
+        }
+      } catch (error) {
+        console.error('Error fetching location name:', error);
+        // Keep using slug as fallback
       }
     };
 
@@ -88,7 +123,7 @@ export default function PublicReservationFlow({
         });
 
         // Redirect to member login after a short delay
-        setTimeout(() => {
+        redirectTimeoutRef.current = setTimeout(() => {
           window.location.href = '/member/login';
         }, 2000);
       } else {
@@ -137,6 +172,9 @@ export default function PublicReservationFlow({
         onClick={handleClose}
       >
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="phone-modal-title"
           style={{
             backgroundColor: '#ECEDE8',
             borderRadius: '16px',
@@ -150,11 +188,12 @@ export default function PublicReservationFlow({
         >
           {/* Header */}
           <div style={{ marginBottom: '0.5rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <h2 style={{ fontSize: '1.125rem', fontWeight: '600', color: '#1F1F1F', margin: 0 }}>
+            <h2 id="phone-modal-title" style={{ fontSize: '1.125rem', fontWeight: '600', color: '#1F1F1F', margin: 0 }}>
               Make a Reservation for {locationName}
             </h2>
             <button
               onClick={handleClose}
+              aria-label="Close reservation modal"
               style={{
                 background: 'none',
                 border: 'none',
@@ -257,6 +296,9 @@ export default function PublicReservationFlow({
         onClick={handleClose}
       >
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="fee-modal-title"
           style={{
             backgroundColor: '#ECEDE8',
             borderRadius: '16px',
@@ -270,11 +312,12 @@ export default function PublicReservationFlow({
         >
           {/* Header */}
           <div style={{ marginBottom: '1.5rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <h2 style={{ fontSize: '1.125rem', fontWeight: '600', color: '#1F1F1F', margin: 0 }}>
+            <h2 id="fee-modal-title" style={{ fontSize: '1.125rem', fontWeight: '600', color: '#1F1F1F', margin: 0 }}>
               Reservation Fee
             </h2>
             <button
               onClick={handleClose}
+              aria-label="Close reservation fee modal"
               style={{
                 background: 'none',
                 border: 'none',
@@ -345,7 +388,7 @@ export default function PublicReservationFlow({
               </p>
               <button
                 onClick={() => {
-                  window.location.href = 'sms:9137774488?body=MEMBERSHIP';
+                  window.location.href = `sms:${MEMBERSHIP_PHONE}?body=${MEMBERSHIP_SMS_BODY}`;
                 }}
                 style={{
                   width: '100%',

--- a/src/components/member/SimpleReservationRequestModal.tsx
+++ b/src/components/member/SimpleReservationRequestModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { DateTime } from 'luxon';
-import { X } from 'lucide-react';
+import { X, ArrowLeft } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { loadStripe } from '@stripe/stripe-js';
 import { Elements, PaymentElement, useStripe, useElements } from '@stripe/react-stripe-js';
@@ -28,6 +28,7 @@ interface Props {
    * @default false
    */
   adminOverride?: boolean;
+  onBack?: () => void;
 }
 
 // Generate time options
@@ -119,6 +120,7 @@ export default function SimpleReservationRequestModal({
   locationSlug,
   hideTableSelection = false,
   adminOverride = false,
+  onBack,
 }: Props) {
   const { toast } = useToast();
   const [date, setDate] = useState<Date | null>(null);
@@ -139,6 +141,7 @@ export default function SimpleReservationRequestModal({
 
   // Location state - defaults to prop, but user can change
   const [selectedLocation, setSelectedLocation] = useState(locationSlug || 'noirkc');
+  const [locationName, setLocationName] = useState<string>('');
 
   // Cover charge state
   const [coverEnabled, setCoverEnabled] = useState(false);
@@ -177,6 +180,37 @@ export default function SimpleReservationRequestModal({
       setSelectedLocation(locationSlug);
     }
   }, [locationSlug]);
+
+  // Fetch location display name
+  useEffect(() => {
+    const fetchLocationName = async () => {
+      if (!selectedLocation) return;
+
+      try {
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(
+          process.env.NEXT_PUBLIC_SUPABASE_URL!,
+          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+        );
+
+        const { data, error } = await supabase
+          .from('locations')
+          .select('name')
+          .eq('slug', selectedLocation)
+          .single();
+
+        if (data && !error) {
+          setLocationName(data.name);
+        }
+      } catch (error) {
+        console.error('Error fetching location name:', error);
+      }
+    };
+
+    if (isOpen && selectedLocation) {
+      fetchLocationName();
+    }
+  }, [isOpen, selectedLocation]);
 
   // Fetch booking window for selected location
   useEffect(() => {
@@ -497,52 +531,6 @@ export default function SimpleReservationRequestModal({
 
     return (
       <form onSubmit={handlePaymentSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
-        {/* Cover charge notice with membership link */}
-        <div style={{
-          padding: '1.25rem',
-          backgroundColor: '#F9FAFB',
-          borderLeft: '4px solid #A59480',
-          borderRadius: '8px',
-          fontSize: '0.875rem',
-        }}>
-          <p style={{ margin: '0 0 0.75rem 0', color: '#6B7280', lineHeight: '1.5' }}>
-            ${coverPrice} cover charge per person applies (includes first drink)
-          </p>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.preventDefault();
-              const message = "MEMBERSHIP";
-              const phoneNumber = "9137774488";
-              const url = `sms:${phoneNumber}?body=${encodeURIComponent(message)}`;
-              window.open(url, '_blank');
-            }}
-            style={{
-              background: 'none',
-              border: 'none',
-              color: '#A59480',
-              cursor: 'pointer',
-              padding: 0,
-              font: 'inherit',
-              fontWeight: '600',
-              fontSize: '0.875rem',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.375rem',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.color = '#8C7C6D';
-              e.currentTarget.style.textDecoration = 'underline';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.color = '#A59480';
-              e.currentTarget.style.textDecoration = 'none';
-            }}
-          >
-            <span>→</span> Become a member and avoid the reservation fee
-          </button>
-        </div>
-
         <div>
           <h3 style={{ fontSize: '1.125rem', fontWeight: '600', marginBottom: '1rem', color: '#1F1F1F' }}>
             Payment Details
@@ -576,46 +564,24 @@ export default function SimpleReservationRequestModal({
           </div>
         )}
 
-        <div style={{ display: 'flex', gap: '0.75rem' }}>
-          <button
-            type="button"
-            onClick={() => {
-              setShowPayment(false);
-              setClientSecret(null);
-            }}
-            style={{
-              flex: 1,
-              height: '48px',
-              backgroundColor: '#F3F4F6',
-              color: '#1F1F1F',
-              fontSize: '1rem',
-              fontWeight: '600',
-              borderRadius: '10px',
-              border: '1px solid #D1D5DB',
-              cursor: 'pointer',
-            }}
-          >
-            Back
-          </button>
-          <button
-            type="submit"
-            disabled={!stripe || paymentProcessing}
-            style={{
-              flex: 2,
-              height: '48px',
-              backgroundColor: paymentProcessing ? '#D1D5DB' : '#A59480',
-              color: 'white',
-              fontSize: '1rem',
-              fontWeight: '600',
-              borderRadius: '10px',
-              border: 'none',
-              cursor: paymentProcessing ? 'not-allowed' : 'pointer',
-              boxShadow: '0 2px 8px rgba(165, 148, 128, 0.2)',
-            }}
-          >
-            {paymentProcessing ? 'Processing...' : `Pay $${parseInt(partySize) * coverPrice}`}
-          </button>
-        </div>
+        <button
+          type="submit"
+          disabled={!stripe || paymentProcessing}
+          style={{
+            width: '100%',
+            height: '48px',
+            backgroundColor: paymentProcessing ? '#D1D5DB' : '#A59480',
+            color: 'white',
+            fontSize: '1rem',
+            fontWeight: '600',
+            borderRadius: '10px',
+            border: 'none',
+            cursor: paymentProcessing ? 'not-allowed' : 'pointer',
+            boxShadow: '0 2px 8px rgba(165, 148, 128, 0.2)',
+          }}
+        >
+          {paymentProcessing ? 'Processing...' : `Pay $${parseInt(partySize) * coverPrice}`}
+        </button>
       </form>
     );
   }
@@ -923,13 +889,27 @@ export default function SimpleReservationRequestModal({
   if (!isOpen) return null;
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
+    <>
+      <style>{`
+        .react-datepicker__portal {
+          position: fixed !important;
+          top: 50% !important;
+          left: 50% !important;
+          transform: translate(-50%, -50%) !important;
+          z-index: 10000 !important;
+        }
+        .react-datepicker__portal .react-datepicker {
+          font-size: 0.875rem;
+          box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4) !important;
+        }
+      `}</style>
+      <div
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
         backgroundColor: 'rgba(0, 0, 0, 0.6)',
         backdropFilter: 'blur(4px)',
         display: 'flex',
@@ -955,9 +935,40 @@ export default function SimpleReservationRequestModal({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div style={{ marginBottom: '1.5rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <h2 style={{ fontSize: '1.5rem', fontWeight: '600', color: '#1F1F1F', margin: 0 }}>
-            {showPayment ? 'Complete Payment' : 'Request a Reservation'}
+        <div style={{ marginBottom: '0.5rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          {onBack ? (
+            <button
+              onClick={onBack}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                padding: '0.625rem',
+                minWidth: '44px',
+                minHeight: '44px',
+                borderRadius: '0.375rem',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#6B7280',
+                transition: 'all 0.2s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = 'rgba(0,0,0,0.05)';
+                e.currentTarget.style.color = '#1F1F1F';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = 'transparent';
+                e.currentTarget.style.color = '#6B7280';
+              }}
+            >
+              <ArrowLeft size={24} />
+            </button>
+          ) : (
+            <div style={{ width: '44px' }} />
+          )}
+          <h2 style={{ fontSize: '1.125rem', fontWeight: '600', color: '#1F1F1F', margin: 0 }}>
+            {showPayment ? 'Complete Payment' : `Request a Reservation for ${locationName || selectedLocation}`}
           </h2>
           <button
             onClick={onClose}
@@ -1037,22 +1048,6 @@ export default function SimpleReservationRequestModal({
               }}
             />
           </div>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="Email (Optional)"
-            style={{
-              width: '100%',
-              height: '44px',
-              padding: '0 1rem',
-              border: '1px solid #D1D5DB',
-              borderRadius: '10px',
-              fontSize: '0.875rem',
-              backgroundColor: 'white',
-              outline: 'none',
-            }}
-          />
           <div>
             <input
               type="tel"
@@ -1074,7 +1069,7 @@ export default function SimpleReservationRequestModal({
           </div>
 
           {/* Location Picker - Only show for members */}
-          {memberId ? (
+          {memberId && (
             <div>
               <select
                 value={selectedLocation}
@@ -1095,34 +1090,17 @@ export default function SimpleReservationRequestModal({
                 <option value="rooftopkc">RooftopKC</option>
               </select>
             </div>
-          ) : (
-            /* Location display for non-members */
-            <div style={{
-              width: '100%',
-              padding: '0.75rem 1rem',
-              border: '1px solid #D1D5DB',
-              borderRadius: '10px',
-              backgroundColor: '#F9FAFB',
-            }}>
-              <p style={{
-                fontSize: '0.75rem',
-                color: '#6B7280',
-                margin: '0 0 0.25rem 0',
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-              }}>
-                Reservation Location
-              </p>
-              <p style={{
-                fontSize: '0.875rem',
-                color: '#1F1F1F',
-                fontWeight: '600',
-                margin: 0,
-              }}>
-                {selectedLocation === 'rooftopkc' ? 'RooftopKC' : 'Noir KC'}
-              </p>
-            </div>
           )}
+
+          {/* Availability Notice */}
+          <div style={{
+            fontSize: '0.8125rem',
+            color: '#374151',
+            textAlign: 'center',
+            lineHeight: '1.5',
+          }}>
+            Due to weather and events, we release our calendar on a week-by-week basis on Mondays.
+          </div>
 
           {/* Date and Time Row */}
           <div style={{ display: 'flex', gap: '1rem' }}>
@@ -1137,6 +1115,10 @@ export default function SimpleReservationRequestModal({
                 dateFormat="MMMM d, yyyy"
                 placeholderText="Date*"
                 openToDate={new Date()}
+                withPortal
+                portalId="datepicker-portal"
+                wrapperClassName="datepicker-wrapper"
+                calendarClassName="simple-calendar"
                 customInput={
                   <input
                     style={{
@@ -1150,13 +1132,8 @@ export default function SimpleReservationRequestModal({
                       outline: 'none',
                       cursor: 'pointer',
                     }}
-                    readOnly
-                    inputMode="none"
-                    onFocus={(e) => e.target.blur()}
                   />
                 }
-                popperPlacement="bottom-start"
-                withPortal={false}
               />
             </div>
 
@@ -1246,24 +1223,16 @@ export default function SimpleReservationRequestModal({
             )}
           </div>
 
-          {/* Special Requests */}
-          <textarea
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            placeholder="Special requests or dietary restrictions (optional)"
-            style={{
-              width: '100%',
-              minHeight: '100px',
-              padding: '0.75rem 1rem',
-              border: '1px solid #D1D5DB',
-              borderRadius: '10px',
-              fontSize: '0.875rem',
-              backgroundColor: 'white',
-              outline: 'none',
-              resize: 'vertical',
-              fontFamily: 'inherit',
-            }}
-          />
+          {/* Food Notice */}
+          <div style={{
+            width: '100%',
+            fontSize: '0.875rem',
+            color: '#6B7280',
+            textAlign: 'center',
+            fontWeight: '600',
+          }}>
+            please note, we do not serve food.
+          </div>
 
           {/* Make Reservation Button */}
           {(() => {
@@ -1272,16 +1241,6 @@ export default function SimpleReservationRequestModal({
 
             return (
               <>
-                {!isFormComplete && (
-                  <div style={{
-                    fontSize: '0.875rem',
-                    color: '#EF4444',
-                    marginTop: '0.5rem',
-                    textAlign: 'center'
-                  }}>
-                    Please fill in all required fields (*)
-                  </div>
-                )}
                 <button
                   onClick={handleMakeReservation}
                   disabled={isDisabled}
@@ -1316,5 +1275,6 @@ export default function SimpleReservationRequestModal({
         )}
       </div>
     </div>
+    </>
   );
 }

--- a/src/components/member/SimpleReservationRequestModal.tsx
+++ b/src/components/member/SimpleReservationRequestModal.tsx
@@ -187,11 +187,7 @@ export default function SimpleReservationRequestModal({
       if (!selectedLocation) return;
 
       try {
-        const { createClient } = await import('@supabase/supabase-js');
-        const supabase = createClient(
-          process.env.NEXT_PUBLIC_SUPABASE_URL!,
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-        );
+        const supabase = getSupabaseClient();
 
         const { data, error } = await supabase
           .from('locations')
@@ -201,6 +197,8 @@ export default function SimpleReservationRequestModal({
 
         if (data && !error) {
           setLocationName(data.name);
+        } else if (error) {
+          console.error('Error fetching location name:', error);
         }
       } catch (error) {
         console.error('Error fetching location name:', error);
@@ -212,18 +210,27 @@ export default function SimpleReservationRequestModal({
     }
   }, [isOpen, selectedLocation]);
 
+  // Handle ESC key to close modal
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+  }, [isOpen, onClose]);
+
   // Fetch booking window for selected location
   useEffect(() => {
     const fetchBookingWindow = async () => {
       if (!isOpen || !selectedLocation) return;
 
       try {
-        // Import supabase client
-        const { createClient } = await import('@supabase/supabase-js');
-        const supabase = createClient(
-          process.env.NEXT_PUBLIC_SUPABASE_URL!,
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-        );
+        const supabase = getSupabaseClient();
 
         // Fetch location-specific booking window and timezone
         // Use public_locations view to avoid exposing minaka_ical_url tokens
@@ -921,6 +928,9 @@ export default function SimpleReservationRequestModal({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="reservation-modal-title"
         style={{
           backgroundColor: '#ECEDE8',
           borderRadius: '16px',
@@ -939,6 +949,7 @@ export default function SimpleReservationRequestModal({
           {onBack ? (
             <button
               onClick={onBack}
+              aria-label="Go back to previous step"
               style={{
                 background: 'none',
                 border: 'none',
@@ -967,11 +978,12 @@ export default function SimpleReservationRequestModal({
           ) : (
             <div style={{ width: '44px' }} />
           )}
-          <h2 style={{ fontSize: '1.125rem', fontWeight: '600', color: '#1F1F1F', margin: 0 }}>
+          <h2 id="reservation-modal-title" style={{ fontSize: '1.125rem', fontWeight: '600', color: '#1F1F1F', margin: 0 }}>
             {showPayment ? 'Complete Payment' : `Request a Reservation for ${locationName || selectedLocation}`}
           </h2>
           <button
             onClick={onClose}
+            aria-label="Close reservation modal"
             style={{
               background: 'none',
               border: 'none',

--- a/src/components/member/SimpleReservationRequestModal.tsx
+++ b/src/components/member/SimpleReservationRequestModal.tsx
@@ -343,11 +343,7 @@ export default function SimpleReservationRequestModal({
 
       // Fetch cover charge info for selected location
       try {
-        const { createClient } = await import('@supabase/supabase-js');
-        const supabase = createClient(
-          process.env.NEXT_PUBLIC_SUPABASE_URL!,
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-        );
+        const supabase = getSupabaseClient();
 
         // Use public_locations view to avoid exposing minaka_ical_url tokens
         const { data: locationData } = await supabase
@@ -910,6 +906,7 @@ export default function SimpleReservationRequestModal({
           box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4) !important;
         }
       `}</style>
+      <div id="datepicker-portal" />
       <div
         style={{
           position: 'fixed',
@@ -946,7 +943,7 @@ export default function SimpleReservationRequestModal({
       >
         {/* Header */}
         <div style={{ marginBottom: '0.5rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          {onBack ? (
+          {onBack && !showPayment ? (
             <button
               onClick={onBack}
               aria-label="Go back to previous step"


### PR DESCRIPTION
## Summary
- Improved public reservation flow with fee transparency and membership upsell
- Enhanced calendar UX with centered popup and availability notices
- Streamlined payment process

## Changes
### Public Reservation Flow
- Added reservation fee notice screen after phone verification
- Shows $20/person fee with clear non-refundable policy
- Two-option layout: continue with reservation or request membership
- Membership request opens SMS to 913.777.4488 with "MEMBERSHIP"
- Back button on reservation form allows return to fee notice

### Calendar & UX Improvements  
- Calendar now appears as centered popup with drop shadow
- Added availability notice: "Due to weather and events, we release our calendar on a week-by-week basis on Mondays"
- Notice appears above date picker for better visibility

### Payment Screen
- Removed $20 cover charge upsell section from payment step
- Removed back button for cleaner, more committed checkout flow
- Full-width Pay button

## Test Plan
- [ ] Phone verification flow works correctly
- [ ] Fee notice displays with both options functional
- [ ] "Request Membership" button opens SMS correctly
- [ ] "Continue with Reservation" proceeds to form
- [ ] Back button on reservation form returns to fee notice
- [ ] Calendar popup appears centered with shadow
- [ ] Availability notice is visible and readable
- [ ] Payment screen shows clean layout without upsell
- [ ] Payment completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)