### PR TITLE
Fix: Mobile horizontal scrolling on reservations timeline

### DIFF
--- a/src/components/ReservationsTimeline.tsx
+++ b/src/components/ReservationsTimeline.tsx
@@ -1100,7 +1100,8 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
               slotDuration: '00:15:00',
               slotLabelInterval: '01:00:00',
               slotMinWidth: isMobile ? 40 : 60,
-              eventMinHeight: isMobile ? 20 : 25,
+              eventMinHeight: isMobile ? 18 : 25, // Smaller to fit in 30px rows
+              eventMaxHeight: isMobile ? 28 : 40, // Cap max height on mobile
             }
           }}
 
@@ -1133,7 +1134,7 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
 
           // Layout configuration
           height="auto"
-          expandRows={true}
+          expandRows={!isMobile} // Only expand rows on desktop, fixed height on mobile
           stickyHeaderDates={true}
           handleWindowResize={true}
 
@@ -1203,27 +1204,6 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
             );
           }}
 
-          // Mount hooks for additional customization without CSS overrides
-          viewDidMount={(arg) => {
-            // Add mobile class for targeted styling
-            if (isMobile) {
-              arg.el.classList.add('fc-mobile');
-            }
-          }}
-
-          resourceLaneDidMount={(arg) => {
-            // Ensure proper min-height without forcing exact height
-            if (isMobile) {
-              arg.el.style.minHeight = '30px';
-            }
-          }}
-
-          slotLaneDidMount={(arg) => {
-            // Ensure slot lanes have proper min-height
-            if (isMobile) {
-              arg.el.style.minHeight = '30px';
-            }
-          }}
         />
       </Box>
     </Box>

--- a/src/components/ReservationsTimeline.tsx
+++ b/src/components/ReservationsTimeline.tsx
@@ -1035,7 +1035,7 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
     <Box className={styles.timelineWrapper}>
       {isMobile && (
         <div className={styles.mobileNavBar}>
-          <button 
+          <button
             className={styles.mobileNavButton}
             onClick={handlePrevDay}
             aria-label="Previous day"
@@ -1045,7 +1045,7 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
           <div className={styles.mobileNavTitle}>
             {formatMobileDate(currentCalendarDate)}
           </div>
-          <button 
+          <button
             className={styles.mobileNavButton}
             onClick={handleNextDay}
             aria-label="Next day"
@@ -1091,7 +1091,20 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
           })()}
           timeZone={settings.timezone}
           schedulerLicenseKey="CC-Attribution-NonCommercial-NoDerivatives"
-          
+
+          // Enhanced custom views for mobile vs desktop
+          views={{
+            resourceTimelineDay: {
+              type: 'resourceTimeline',
+              duration: { days: 1 },
+              slotDuration: '00:15:00',
+              slotLabelInterval: '01:00:00',
+              slotMinWidth: isMobile ? 40 : 60,
+              eventMinHeight: isMobile ? 20 : 25,
+            }
+          }}
+
+          // Custom buttons
           customButtons={{
             makeReservation: {
               text: 'Make Reservation',
@@ -1111,46 +1124,59 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
             },
           }}
 
+          // Header configuration
           headerToolbar={isMobile ? false : {
             left: 'prev,next',
             center: 'title',
             right: onPrivateEventRSVPClick ? 'privateEventRSVPs,makeReservation,today' : 'makeReservation,today',
           }}
-          titleFormat={{ weekday: 'long', month: 'long', day: 'numeric' }}
-          resources={resources}
-          events={events}
-          editable={true}
-          droppable={true}
-          selectable={!isTouchDevice()}
-          eventDrop={handleEventDrop}
-          eventResize={handleEventResize}
-          eventClick={handleEventClick}
-          select={handleSlotClick}
-          height={isMobile ? 'auto' : 'auto'}
-          
-          scrollTime={scrollTime}
-          scrollTimeReset={false}
+
+          // Layout configuration
+          height="auto"
+          expandRows={true}
+          stickyHeaderDates={true}
           handleWindowResize={true}
-          
-          longPressDelay={isTouchDeviceState ? 300 : 1000}
-          eventLongPressDelay={isTouchDeviceState ? 300 : 1000}
-          selectLongPressDelay={isTouchDeviceState ? 300 : 1000}
-          
-          eventDragMinDistance={isTouchDeviceState ? 5 : 3}
-          eventDragStart={handleEventDragStart}
-          eventDragStop={handleEventDragStop}
-          
+
+          // Time configuration
           slotMinTime={slotMinTime}
           slotMaxTime={slotMaxTime}
           slotDuration="00:15:00"
           slotLabelInterval="01:00:00"
-          slotLabelFormat={[
-            { hour: 'numeric', hour12: true },
-          ]}
-          nowIndicator
+          slotLabelFormat={{ hour: 'numeric', hour12: true }}
+          scrollTime={scrollTime}
+          scrollTimeReset={false}
+          nowIndicator={true}
+
+          // Resource configuration
           resourceAreaWidth={isMobile ? "40px" : "80px"}
           resourceAreaHeaderContent=""
-          
+          resources={resources}
+
+          // Format configuration
+          titleFormat={{ weekday: 'long', month: 'long', day: 'numeric' }}
+
+          // Events
+          events={events}
+
+          // Interaction configuration
+          editable={true}
+          droppable={true}
+          selectable={!isTouchDevice()}
+          longPressDelay={isTouchDeviceState ? 300 : 1000}
+          eventLongPressDelay={isTouchDeviceState ? 300 : 1000}
+          selectLongPressDelay={isTouchDeviceState ? 300 : 1000}
+          eventDragMinDistance={isTouchDeviceState ? 5 : 3}
+
+          // Event handlers
+          eventDrop={handleEventDrop}
+          eventResize={handleEventResize}
+          eventClick={handleEventClick}
+          select={handleSlotClick}
+          datesSet={handleDatesSet}
+          eventDragStart={handleEventDragStart}
+          eventDragStop={handleEventDragStop}
+
+          // Use eventContent to render with proper React components
           eventContent={(arg) => {
             if (arg.event.extendedProps.is_blocking) {
               return (
@@ -1176,7 +1202,28 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
               </div>
             );
           }}
-          datesSet={handleDatesSet}
+
+          // Mount hooks for additional customization without CSS overrides
+          viewDidMount={(arg) => {
+            // Add mobile class for targeted styling
+            if (isMobile) {
+              arg.el.classList.add('fc-mobile');
+            }
+          }}
+
+          resourceLaneDidMount={(arg) => {
+            // Ensure proper min-height without forcing exact height
+            if (isMobile) {
+              arg.el.style.minHeight = '30px';
+            }
+          }}
+
+          slotLaneDidMount={(arg) => {
+            // Ensure slot lanes have proper min-height
+            if (isMobile) {
+              arg.el.style.minHeight = '30px';
+            }
+          }}
         />
       </Box>
     </Box>

--- a/src/components/ReservationsTimeline.tsx
+++ b/src/components/ReservationsTimeline.tsx
@@ -1035,7 +1035,7 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
     <Box className={styles.timelineWrapper}>
       {isMobile && (
         <div className={styles.mobileNavBar}>
-          <button
+          <button 
             className={styles.mobileNavButton}
             onClick={handlePrevDay}
             aria-label="Previous day"
@@ -1045,7 +1045,7 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
           <div className={styles.mobileNavTitle}>
             {formatMobileDate(currentCalendarDate)}
           </div>
-          <button
+          <button 
             className={styles.mobileNavButton}
             onClick={handleNextDay}
             aria-label="Next day"
@@ -1091,21 +1091,7 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
           })()}
           timeZone={settings.timezone}
           schedulerLicenseKey="CC-Attribution-NonCommercial-NoDerivatives"
-
-          // Enhanced custom views for mobile vs desktop
-          views={{
-            resourceTimelineDay: {
-              type: 'resourceTimeline',
-              duration: { days: 1 },
-              slotDuration: '00:15:00',
-              slotLabelInterval: '01:00:00',
-              slotMinWidth: isMobile ? 40 : 60,
-              eventMinHeight: isMobile ? 18 : 25, // Smaller to fit in 30px rows
-              eventMaxHeight: isMobile ? 28 : 40, // Cap max height on mobile
-            }
-          }}
-
-          // Custom buttons
+          
           customButtons={{
             makeReservation: {
               text: 'Make Reservation',
@@ -1125,59 +1111,48 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
             },
           }}
 
-          // Header configuration
           headerToolbar={isMobile ? false : {
             left: 'prev,next',
             center: 'title',
             right: onPrivateEventRSVPClick ? 'privateEventRSVPs,makeReservation,today' : 'makeReservation,today',
           }}
-
-          // Layout configuration
-          height="auto"
-          expandRows={!isMobile} // Only expand rows on desktop, fixed height on mobile
-          stickyHeaderDates={true}
-          handleWindowResize={true}
-
-          // Time configuration
-          slotMinTime={slotMinTime}
-          slotMaxTime={slotMaxTime}
-          slotDuration="00:15:00"
-          slotLabelInterval="01:00:00"
-          slotLabelFormat={{ hour: 'numeric', hour12: true }}
-          scrollTime={scrollTime}
-          scrollTimeReset={false}
-          nowIndicator={true}
-
-          // Resource configuration
-          resourceAreaWidth={isMobile ? "40px" : "80px"}
-          resourceAreaHeaderContent=""
-          resources={resources}
-
-          // Format configuration
           titleFormat={{ weekday: 'long', month: 'long', day: 'numeric' }}
-
-          // Events
+          resources={resources}
           events={events}
-
-          // Interaction configuration
           editable={true}
           droppable={true}
           selectable={!isTouchDevice()}
-          longPressDelay={isTouchDeviceState ? 300 : 1000}
-          eventLongPressDelay={isTouchDeviceState ? 300 : 1000}
-          selectLongPressDelay={isTouchDeviceState ? 300 : 1000}
-          eventDragMinDistance={isTouchDeviceState ? 5 : 3}
-
-          // Event handlers
           eventDrop={handleEventDrop}
           eventResize={handleEventResize}
           eventClick={handleEventClick}
           select={handleSlotClick}
-          datesSet={handleDatesSet}
+          height="auto"
+          
+          scrollTime={scrollTime}
+          scrollTimeReset={false}
+          handleWindowResize={true}
+          slotMinWidth={isMobile ? 50 : 60}
+          
+          longPressDelay={isTouchDeviceState ? 300 : 1000}
+          eventLongPressDelay={isTouchDeviceState ? 300 : 1000}
+          selectLongPressDelay={isTouchDeviceState ? 300 : 1000}
+          
+          eventDragMinDistance={isTouchDeviceState ? 5 : 3}
           eventDragStart={handleEventDragStart}
           eventDragStop={handleEventDragStop}
-
-          // Use eventContent to render with proper React components
+          
+          slotMinTime={slotMinTime}
+          slotMaxTime={slotMaxTime}
+          slotDuration="00:15:00"
+          slotLabelInterval="01:00:00"
+          slotLabelFormat={[
+            { hour: 'numeric', hour12: true },
+          ]}
+          nowIndicator
+          resourceAreaWidth={isMobile ? "40px" : "80px"}
+          resourceAreaHeaderContent=""
+          aspectRatio={isMobile ? undefined : 1.5}
+          
           eventContent={(arg) => {
             if (arg.event.extendedProps.is_blocking) {
               return (
@@ -1203,7 +1178,7 @@ const ReservationsTimeline: React.FC<ReservationsTimelineProps> = ({
               </div>
             );
           }}
-
+          datesSet={handleDatesSet}
         />
       </Box>
     </Box>

--- a/src/styles/ReservationsTimeline.module.css
+++ b/src/styles/ReservationsTimeline.module.css
@@ -1,5 +1,4 @@
-/* Reservations Timeline - Essential Styles Only */
-/* Layout/sizing handled via FullCalendar configuration API */
+/* Reservations Timeline Styles */
 
 .timelineWrapper {
   width: 100%;
@@ -13,89 +12,138 @@
   width: 100%;
   height: 100%;
   font-family: 'Montserrat', sans-serif;
-  flex: 1;
-  overflow: auto;
 }
 
-/* Typography */
+/* FullCalendar overrides */
 .calendarContainer :global(.fc) {
   font-family: 'Montserrat', sans-serif;
 }
 
+/* Reduce title font size */
 .calendarContainer :global(.fc-toolbar-title) {
-  font-size: 1.0rem;
-  font-weight: 400;
+  font-size: 1.0rem !important;
+  font-weight: 400 !important;
 }
 
-/* Custom button styling */
-.calendarContainer :global(.fc-button-primary) {
-  background-color: #353535;
-  border-color: #353535;
+/* Custom button styling for new reservation button */
+.calendarContainer :global(.fc-newRez-button) {
+  background-color: #34c759 !important;
+  border-color: #34c759 !important;
+  color: #ffffff !important;
+  margin-right: 0.5em !important;
 }
 
-.calendarContainer :global(.fc-button-primary:hover) {
-  background-color: #4a4a4a;
-  border-color: #4a4a4a;
+.calendarContainer :global(.fc-newRez-button:hover) {
+  background-color: #28a745 !important;
+  border-color: #28a745 !important;
 }
 
-/* Resource area styling */
 .calendarContainer :global(.fc-resource-area) {
   background-color: #ecede8;
+  color: white;
+  vertical-align: middle;
+  text-align: center;
+  font-family: 'Montserrat', sans-serif;
+  min-width: 80px;
+  width: 80px;
+  flex-shrink: 0;
 }
 
-.calendarContainer :global(.fc-datagrid-cell-main) {
-  color: #353535;
+.calendarContainer :global(.fc-resource-area .fc-resource-title) {
+  color: white;
+  vertical-align: middle;
+  font-family: 'Montserrat', sans-serif;
   font-size: 12px;
+  padding: 8px 2px;
   text-align: center;
 }
 
-/* Timeline background */
 .calendarContainer :global(.fc-timeline-header),
 .calendarContainer :global(.fc-timeline-body) {
+  border-right: 1px solid rgba(0, 0, 0, 0.12);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   background-color: #ecede8;
 }
 
-/* Event base styling */
 .calendarContainer :global(.fc-event) {
-  border: none;
-  border-radius: 4px;
+  border: 0 !important;
+  outline: 0 !important;
+  padding: 0px !important;
+  border-radius: 5px !important;
+  box-shadow: 5px 5px 15px 0.5px !important;
+  margin: 0px;
   cursor: pointer;
   user-select: none;
 }
 
 .reservationEvent {
   font-family: 'Montserrat', sans-serif;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: flex;
+  white-space: normal;
+  margin: 0px;
+  display: center;
   align-items: center;
-  padding: 2px 4px;
-  font-size: 12px;
+  justify-content: center;
+  height: 24px;
+  font-size: 14px;
   border-radius: 4px;
+  padding: 0 2px;
   border: 1px solid #353535;
   cursor: pointer;
   user-select: none;
-  min-height: 24px;
+  touch-action: manipulation;
 }
 
 .blockingEvent {
   font-family: 'Montserrat', sans-serif;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: flex;
+  white-space: normal;
+  margin: 0px;
+  display: center;
   align-items: center;
-  padding: 2px 4px;
-  font-size: 12px;
+  justify-content: center;
+  height: 24px;
+  font-size: 14px;
   background: #6b7280;
   color: #ffffff;
   border-radius: 4px;
+  padding: 0 2px;
   border: 1px solid #6b7280;
   cursor: not-allowed;
   user-select: none;
+  touch-action: manipulation;
   opacity: 0.8;
-  min-height: 24px;
+}
+
+/* Exceptional closure blocking events (custom closed days) */
+.calendarContainer :global(.exceptional-closure-blocking) {
+  background-color: #6b7280 !important;
+  border-color: #6b7280 !important;
+  opacity: 0.8 !important;
+}
+
+/* Fix for private event blocking - remove ALL ::before pseudo-elements from timeline events */
+.calendarContainer :global(.fc-timeline-event:before),
+.calendarContainer :global(.fc-timeline-event:not(.fc-event-end):before),
+.calendarContainer :global(.fc-timeline-event:not(.fc-event-start):before),
+.calendarContainer :global(.fc-event.private-event-blocking:before),
+.calendarContainer :global(.fc-event.exceptional-closure-blocking:before),
+.calendarContainer :global(.private-event-blocking):before,
+.calendarContainer :global(.exceptional-closure-blocking):before {
+  content: none !important;
+}
+
+/* Force correct height for private event blocking events */
+.calendarContainer :global(.fc-event.private-event-blocking),
+.calendarContainer :global(.fc-event.exceptional-closure-blocking) {
+  height: auto !important;
+  max-height: 30px !important;
+}
+
+/* Ensure the event main content doesn't have extra height */
+.calendarContainer :global(.fc-event.private-event-blocking .fc-event-main),
+.calendarContainer :global(.fc-event.exceptional-closure-blocking .fc-event-main) {
+  height: 100% !important;
+  display: flex !important;
+  align-items: center !important;
 }
 
 /* Mobile Navigation Bar */
@@ -108,28 +156,38 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.25rem 0.5rem;
+    padding: 0.2rem 0.5rem;
     background: #ffffff;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-    gap: 0.25rem;
-    min-height: 44px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    flex-shrink: 0;
+    min-height: 38px;
   }
 
   .mobileNavButton {
-    min-width: 30px;
-    height: 35px;
+    width: 24px;
+    height: 30px !important;
+    min-height: 30px !important;
+    max-height: 30px !important;
+    line-height: 30px;
     display: flex;
     align-items: center;
     justify-content: center;
     background: #f5f5f7;
     border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: 4px;
-    font-size: 14px;
+    font-size: 12px;
     font-weight: 600;
     color: #1d1d1f;
     cursor: pointer;
     transition: all 0.2s;
     -webkit-tap-highlight-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    box-sizing: border-box;
+    padding: 2px;
   }
 
   .mobileNavButton:active {
@@ -140,10 +198,11 @@
   .mobileNavTitle {
     flex: 1;
     text-align: center;
-    font-size: 0.75rem;
+    font-size: 0.6875rem;
     font-weight: 500;
     color: #1d1d1f;
     padding: 0 0.25rem;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   }
 
   .mobileNavToday {
@@ -151,14 +210,22 @@
     color: #ffffff;
     border: none;
     border-radius: 4px;
-    padding: 0 0.75rem;
-    height: 35px;
-    font-size: 0.75rem;
+    font-size: 0.625rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.2s;
     -webkit-tap-highlight-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     white-space: nowrap;
+    height: 30px !important;
+    min-height: 30px !important;
+    max-height: 30px !important;
+    line-height: 30px;
+    padding: 2px 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
   }
 
   .mobileNavToday:active {
@@ -171,15 +238,23 @@
     color: #ffffff;
     border: none;
     border-radius: 4px;
-    padding: 0 0.5rem;
-    height: 35px;
-    font-size: 0.7rem;
+    font-size: 0.625rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.2s;
     -webkit-tap-highlight-color: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     white-space: nowrap;
     margin-left: 0.25rem;
+    height: 30px !important;
+    min-height: 30px !important;
+    max-height: 30px !important;
+    line-height: 30px;
+    padding: 2px 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
   }
 
   .mobileNavNewRez:active {
@@ -187,76 +262,185 @@
     transform: scale(0.95);
   }
 
-  /* Mobile-specific adjustments */
+  .timelineWrapper {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .calendarContainer {
+    flex: 1;
+    min-height: 0;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Let FullCalendar handle its own scrolling - remove all overrides */
+
   .reservationEvent {
+    min-height: 24px;
     font-size: 10px;
-    min-height: 20px;
+    padding: 0 3px;
   }
 
   .blockingEvent {
+    min-height: 24px;
     font-size: 10px;
-    min-height: 20px;
+    padding: 0 3px;
   }
 
-  .calendarContainer :global(.fc-datagrid-cell-main) {
-    font-size: 10px;
+  .calendarContainer :global(.fc-resource-area) {
+    min-width: 40px;
+    width: 40px;
   }
 
-  /* Prevent scroll snap-back */
-  .calendarContainer :global(.fc-scroller) {
-    overscroll-behavior-x: contain;
+  /* Remove height constraints that break scrolling */
+
+  /* Smaller fonts for timeline elements */
+  .calendarContainer :global(.fc-timeline-slot-label) {
+    font-size: 10px !important;
   }
 
-  /* Force 30px row heights on mobile */
-  .calendarContainer :global(.fc-timeline-lane) {
-    height: 30px !important;
+  .calendarContainer :global(.fc-timeline-slot) {
+    font-size: 10px !important;
   }
 
-  .calendarContainer :global(.fc-timeline-lane-frame) {
-    height: 30px !important;
+  .calendarContainer :global(.fc-timegrid-slot-label) {
+    font-size: 10px !important;
   }
 
-  /* Force resource column rows to match */
-  .calendarContainer :global(.fc-datagrid-body tr) {
-    height: 30px !important;
+  .calendarContainer :global(.fc-resource-area .fc-resource-title) {
+    font-size: 10px !important;
+    padding: 4px 2px !important;
   }
 
-  .calendarContainer :global(.fc-datagrid-cell) {
-    height: 30px !important;
+  .calendarContainer :global(.fc-timeline-header-cell) {
+    font-size: 10px !important;
   }
 
-  .calendarContainer :global(.fc-datagrid-cell-frame) {
-    height: 30px !important;
+  .calendarContainer :global(.fc-col-header-cell) {
+    font-size: 10px !important;
   }
 
-  .calendarContainer :global(.fc-datagrid-cell-cushion) {
-    height: 30px !important;
-    padding: 0 !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-  }
-
-  /* Timeline slot frames */
-  .calendarContainer :global(.fc-timeline-slot-frame) {
-    height: 30px !important;
-  }
-
-  /* Event harness height */
+  /* Fix mobile event harness height to fit content */
   .calendarContainer :global(.fc-timeline-event-harness) {
-    height: auto !important;
-    min-height: 20px !important;
-    max-height: 28px !important;
+    min-height: 24px !important;
   }
 
-  /* Header row heights */
-  .calendarContainer :global(.fc-timeline-header-row) {
-    height: 24px !important;
+  /* Ensure the event itself also uses auto height */
+  .calendarContainer :global(.fc-timeline-event) {
+    min-height: 24px !important;
   }
 
-  .calendarContainer :global(.fc-timeline-slot-cushion) {
-    height: 24px !important;
-    padding: 0 2px !important;
+  /* Make sure the inner event takes up full space */
+  .calendarContainer :global(.fc-event.fc-h-event) {
+    min-height: 24px !important;
+  }
+
+  /* Remove ALL height forcing - let FullCalendar handle it */
+
+
+  /* Keep header compact but don't force heights that break scrolling */
+  .calendarContainer :global(.fc-timeline-header .fc-timeline-slot-label) {
     font-size: 9px !important;
+    font-weight: 500 !important;
+  }
+
+  /* Remove gap between header and body sections */
+  .calendarContainer :global(.fc-scrollgrid-section) {
+    border: none !important;
+  }
+
+  .calendarContainer :global(.fc-scrollgrid-section-body) {
+    border-top: none !important;
+  }
+
+  .calendarContainer :global(.fc-timeline .fc-scrollgrid-section > td) {
+    border: none !important;
+  }
+
+  /* Remove any margins/padding that create gaps */
+  .calendarContainer :global(.fc-timeline-body) {
+    margin-top: 0 !important;
+    padding-top: 0 !important;
+  }
+
+  .calendarContainer :global(.fc-datagrid-body) {
+    margin-top: 0 !important;
+    padding-top: 0 !important;
+  }
+
+  /* Remove border spacing and collapse borders on tables */
+  .calendarContainer :global(.fc-scrollgrid) {
+    border-spacing: 0 !important;
+    border-collapse: collapse !important;
+  }
+
+  .calendarContainer :global(.fc-scrollgrid table) {
+    border-spacing: 0 !important;
+    border-collapse: collapse !important;
+  }
+
+  /* Remove any top border from the first body row */
+  .calendarContainer :global(.fc-scrollgrid-section-body tr:first-child td) {
+    border-top: none !important;
+  }
+
+  .calendarContainer :global(.fc-timeline-body tr:first-child td) {
+    border-top: none !important;
+  }
+
+  /* Make the resource column (table numbers) narrower on mobile */
+  .calendarContainer :global(.fc-resource-timeline colgroup col:first-child) {
+    width: 40px !important;
+    max-width: 40px !important;
+  }
+
+  /* Make the resource timeline divider column specifically 3px */
+  .calendarContainer :global(colgroup col:nth-child(2)) {
+    width: 3px !important;
+    min-width: 3px !important;
+    max-width: 3px !important;
+  }
+
+  /* Also ensure the td cell containing the divider is thin */
+  .calendarContainer :global(td.fc-resource-timeline-divider) {
+    width: 3px !important;
+    min-width: 3px !important;
+    max-width: 3px !important;
+    padding: 0 !important;
+    height: auto !important;
+  }
+
+  /* Fix divider header cell */
+  .calendarContainer :global(.fc-timeline-header td.fc-resource-timeline-divider) {
+    vertical-align: top !important;
+  }
+
+  /* Ensure divider doesn't create gaps */
+  .calendarContainer :global(.fc-resource-timeline-divider .fc-datagrid-cell-frame) {
+    padding: 0 !important;
+    border: none !important;
+  }
+
+  /* Make table numbers same font size as reservations on mobile */
+  .calendarContainer :global(.fc-datagrid-cell-main) {
+    font-size: 10px !important;
+  }
+
+  /* Also target the resource cell text specifically */
+  .calendarContainer :global(.fc-resource-timeline .fc-datagrid-cell) {
+    font-size: 10px !important;
+  }
+
+  /* Simple styling for datagrid cells */
+  .calendarContainer :global(.fc-datagrid-body .fc-datagrid-cell-cushion) {
+    padding: 8px 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 }
+
+

--- a/src/styles/ReservationsTimeline.module.css
+++ b/src/styles/ReservationsTimeline.module.css
@@ -206,4 +206,57 @@
   .calendarContainer :global(.fc-scroller) {
     overscroll-behavior-x: contain;
   }
+
+  /* Force 30px row heights on mobile */
+  .calendarContainer :global(.fc-timeline-lane) {
+    height: 30px !important;
+  }
+
+  .calendarContainer :global(.fc-timeline-lane-frame) {
+    height: 30px !important;
+  }
+
+  /* Force resource column rows to match */
+  .calendarContainer :global(.fc-datagrid-body tr) {
+    height: 30px !important;
+  }
+
+  .calendarContainer :global(.fc-datagrid-cell) {
+    height: 30px !important;
+  }
+
+  .calendarContainer :global(.fc-datagrid-cell-frame) {
+    height: 30px !important;
+  }
+
+  .calendarContainer :global(.fc-datagrid-cell-cushion) {
+    height: 30px !important;
+    padding: 0 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+  }
+
+  /* Timeline slot frames */
+  .calendarContainer :global(.fc-timeline-slot-frame) {
+    height: 30px !important;
+  }
+
+  /* Event harness height */
+  .calendarContainer :global(.fc-timeline-event-harness) {
+    height: auto !important;
+    min-height: 20px !important;
+    max-height: 28px !important;
+  }
+
+  /* Header row heights */
+  .calendarContainer :global(.fc-timeline-header-row) {
+    height: 24px !important;
+  }
+
+  .calendarContainer :global(.fc-timeline-slot-cushion) {
+    height: 24px !important;
+    padding: 0 2px !important;
+    font-size: 9px !important;
+  }
 }

--- a/src/styles/ReservationsTimeline.module.css
+++ b/src/styles/ReservationsTimeline.module.css
@@ -1,4 +1,5 @@
-/* Reservations Timeline Styles */
+/* Reservations Timeline - Essential Styles Only */
+/* Layout/sizing handled via FullCalendar configuration API */
 
 .timelineWrapper {
   width: 100%;
@@ -12,138 +13,89 @@
   width: 100%;
   height: 100%;
   font-family: 'Montserrat', sans-serif;
+  flex: 1;
+  overflow: auto;
 }
 
-/* FullCalendar overrides */
+/* Typography */
 .calendarContainer :global(.fc) {
   font-family: 'Montserrat', sans-serif;
 }
 
-/* Reduce title font size */
 .calendarContainer :global(.fc-toolbar-title) {
-  font-size: 1.0rem !important;
-  font-weight: 400 !important;
+  font-size: 1.0rem;
+  font-weight: 400;
 }
 
-/* Custom button styling for new reservation button */
-.calendarContainer :global(.fc-newRez-button) {
-  background-color: #34c759 !important;
-  border-color: #34c759 !important;
-  color: #ffffff !important;
-  margin-right: 0.5em !important;
+/* Custom button styling */
+.calendarContainer :global(.fc-button-primary) {
+  background-color: #353535;
+  border-color: #353535;
 }
 
-.calendarContainer :global(.fc-newRez-button:hover) {
-  background-color: #28a745 !important;
-  border-color: #28a745 !important;
+.calendarContainer :global(.fc-button-primary:hover) {
+  background-color: #4a4a4a;
+  border-color: #4a4a4a;
 }
 
+/* Resource area styling */
 .calendarContainer :global(.fc-resource-area) {
   background-color: #ecede8;
-  color: white;
-  vertical-align: middle;
-  text-align: center;
-  font-family: 'Montserrat', sans-serif;
-  min-width: 80px;
-  width: 80px;
-  flex-shrink: 0;
 }
 
-.calendarContainer :global(.fc-resource-area .fc-resource-title) {
-  color: white;
-  vertical-align: middle;
-  font-family: 'Montserrat', sans-serif;
+.calendarContainer :global(.fc-datagrid-cell-main) {
+  color: #353535;
   font-size: 12px;
-  padding: 8px 2px;
   text-align: center;
 }
 
+/* Timeline background */
 .calendarContainer :global(.fc-timeline-header),
 .calendarContainer :global(.fc-timeline-body) {
-  border-right: 1px solid rgba(0, 0, 0, 0.12);
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   background-color: #ecede8;
 }
 
+/* Event base styling */
 .calendarContainer :global(.fc-event) {
-  border: 0 !important;
-  outline: 0 !important;
-  padding: 0px !important;
-  border-radius: 5px !important;
-  box-shadow: 5px 5px 15px 0.5px !important;
-  margin: 0px;
+  border: none;
+  border-radius: 4px;
   cursor: pointer;
   user-select: none;
 }
 
 .reservationEvent {
   font-family: 'Montserrat', sans-serif;
-  white-space: normal;
-  margin: 0px;
-  display: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: flex;
   align-items: center;
-  justify-content: center;
-  height: 24px;
-  font-size: 14px;
+  padding: 2px 4px;
+  font-size: 12px;
   border-radius: 4px;
-  padding: 0 2px;
   border: 1px solid #353535;
   cursor: pointer;
   user-select: none;
-  touch-action: manipulation;
+  min-height: 24px;
 }
 
 .blockingEvent {
   font-family: 'Montserrat', sans-serif;
-  white-space: normal;
-  margin: 0px;
-  display: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: flex;
   align-items: center;
-  justify-content: center;
-  height: 24px;
-  font-size: 14px;
+  padding: 2px 4px;
+  font-size: 12px;
   background: #6b7280;
   color: #ffffff;
   border-radius: 4px;
-  padding: 0 2px;
   border: 1px solid #6b7280;
   cursor: not-allowed;
   user-select: none;
-  touch-action: manipulation;
   opacity: 0.8;
-}
-
-/* Exceptional closure blocking events (custom closed days) */
-.calendarContainer :global(.exceptional-closure-blocking) {
-  background-color: #6b7280 !important;
-  border-color: #6b7280 !important;
-  opacity: 0.8 !important;
-}
-
-/* Fix for private event blocking - remove ALL ::before pseudo-elements from timeline events */
-.calendarContainer :global(.fc-timeline-event:before),
-.calendarContainer :global(.fc-timeline-event:not(.fc-event-end):before),
-.calendarContainer :global(.fc-timeline-event:not(.fc-event-start):before),
-.calendarContainer :global(.fc-event.private-event-blocking:before),
-.calendarContainer :global(.fc-event.exceptional-closure-blocking:before),
-.calendarContainer :global(.private-event-blocking):before,
-.calendarContainer :global(.exceptional-closure-blocking):before {
-  content: none !important;
-}
-
-/* Force correct height for private event blocking events */
-.calendarContainer :global(.fc-event.private-event-blocking),
-.calendarContainer :global(.fc-event.exceptional-closure-blocking) {
-  height: auto !important;
-  max-height: 30px !important;
-}
-
-/* Ensure the event main content doesn't have extra height */
-.calendarContainer :global(.fc-event.private-event-blocking .fc-event-main),
-.calendarContainer :global(.fc-event.exceptional-closure-blocking .fc-event-main) {
-  height: 100% !important;
-  display: flex !important;
-  align-items: center !important;
+  min-height: 24px;
 }
 
 /* Mobile Navigation Bar */
@@ -156,38 +108,28 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.2rem 0.5rem;
+    padding: 0.25rem 0.5rem;
     background: #ffffff;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-    position: sticky;
-    top: 0;
-    z-index: 10;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-    flex-shrink: 0;
-    min-height: 38px;
+    gap: 0.25rem;
+    min-height: 44px;
   }
 
   .mobileNavButton {
-    width: 24px;
-    height: 30px !important;
-    min-height: 30px !important;
-    max-height: 30px !important;
-    line-height: 30px;
+    min-width: 30px;
+    height: 35px;
     display: flex;
     align-items: center;
     justify-content: center;
     background: #f5f5f7;
     border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: 4px;
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 600;
     color: #1d1d1f;
     cursor: pointer;
     transition: all 0.2s;
     -webkit-tap-highlight-color: transparent;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    box-sizing: border-box;
-    padding: 2px;
   }
 
   .mobileNavButton:active {
@@ -198,11 +140,10 @@
   .mobileNavTitle {
     flex: 1;
     text-align: center;
-    font-size: 0.6875rem;
+    font-size: 0.75rem;
     font-weight: 500;
     color: #1d1d1f;
     padding: 0 0.25rem;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   }
 
   .mobileNavToday {
@@ -210,22 +151,14 @@
     color: #ffffff;
     border: none;
     border-radius: 4px;
-    font-size: 0.625rem;
+    padding: 0 0.75rem;
+    height: 35px;
+    font-size: 0.75rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.2s;
     -webkit-tap-highlight-color: transparent;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     white-space: nowrap;
-    height: 30px !important;
-    min-height: 30px !important;
-    max-height: 30px !important;
-    line-height: 30px;
-    padding: 2px 0.5rem;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    box-sizing: border-box;
   }
 
   .mobileNavToday:active {
@@ -238,23 +171,15 @@
     color: #ffffff;
     border: none;
     border-radius: 4px;
-    font-size: 0.625rem;
+    padding: 0 0.5rem;
+    height: 35px;
+    font-size: 0.7rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.2s;
     -webkit-tap-highlight-color: transparent;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     white-space: nowrap;
     margin-left: 0.25rem;
-    height: 30px !important;
-    min-height: 30px !important;
-    max-height: 30px !important;
-    line-height: 30px;
-    padding: 2px 0.5rem;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    box-sizing: border-box;
   }
 
   .mobileNavNewRez:active {
@@ -262,398 +187,23 @@
     transform: scale(0.95);
   }
 
-  .timelineWrapper {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-height: 0;
-  }
-
-  .calendarContainer {
-    flex: 1;
-    overflow: auto;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-    -webkit-overflow-scrolling: touch;
-  }
-
-  /* Prevent scroll snap-back on mobile timeline */
-  .calendarContainer :global(.fc-scroller) {
-    scroll-snap-type: none !important;
-    overscroll-behavior-x: contain !important;
-  }
-
-  .calendarContainer :global(.fc-scroller-liquid) {
-    scroll-snap-type: none !important;
-    overscroll-behavior-x: contain !important;
-  }
-
-  .calendarContainer :global(.fc-timeline .fc-scroller-liquid-absolute) {
-    overflow-x: auto !important;
-    -webkit-overflow-scrolling: touch !important;
-    overscroll-behavior-x: contain !important;
-  }
-
+  /* Mobile-specific adjustments */
   .reservationEvent {
-    min-height: 24px;
     font-size: 10px;
-    padding: 0 3px;
+    min-height: 20px;
   }
 
   .blockingEvent {
-    min-height: 24px;
     font-size: 10px;
-    padding: 0 3px;
+    min-height: 20px;
   }
 
-  .calendarContainer :global(.fc-resource-area) {
-    min-width: 40px;
-    width: 40px;
-  }
-
-  .calendarContainer :global(.fc) {
-    height: 100% !important;
-  }
-
-  .calendarContainer :global(.fc-view-harness) {
-    height: 100% !important;
-  }
-
-  /* Smaller fonts for timeline elements */
-  .calendarContainer :global(.fc-timeline-slot-label) {
-    font-size: 10px !important;
-  }
-
-  .calendarContainer :global(.fc-timeline-slot) {
-    font-size: 10px !important;
-  }
-
-  .calendarContainer :global(.fc-timegrid-slot-label) {
-    font-size: 10px !important;
-  }
-
-  .calendarContainer :global(.fc-resource-area .fc-resource-title) {
-    font-size: 10px !important;
-    padding: 4px 2px !important;
-  }
-
-  .calendarContainer :global(.fc-timeline-header-cell) {
-    font-size: 10px !important;
-  }
-
-  .calendarContainer :global(.fc-col-header-cell) {
-    font-size: 10px !important;
-  }
-
-  /* Fix mobile event harness height to fit content */
-  .calendarContainer :global(.fc-timeline-event-harness) {
-    min-height: 24px !important;
-  }
-
-  /* Ensure the event itself also uses auto height */
-  .calendarContainer :global(.fc-timeline-event) {
-    min-height: 24px !important;
-  }
-
-  /* Make sure the inner event takes up full space */
-  .calendarContainer :global(.fc-event.fc-h-event) {
-    min-height: 24px !important;
-  }
-
-  /* Make timeline slot frames dynamic height on mobile */
-  .calendarContainer :global(.fc-timeline-slot-frame) {
-    height: auto !important;
-    min-height: 30px !important;
-  }
-
-  /* Also override datagrid cell frame heights on mobile */
-  .calendarContainer :global(.fc-datagrid-cell-frame) {
-    height: auto !important;
-    min-height: 30px !important;
-  }
-
-  /* Force timeline lanes and datagrid rows to match heights - COMPACT for mobile */
-  .calendarContainer :global(.fc-timeline-lane) {
-    height: 30px !important; /* Compact height for mobile */
-  }
-
-  /* Force timeline lane frames to match */
-  .calendarContainer :global(.fc-timeline-lane-frame),
-  .calendarContainer :global(.fc-timeline-lane .fc-timeline-lane-frame),
-  .calendarContainer :global(td.fc-timeline-lane .fc-timeline-lane-frame) {
-    height: 30px !important;
-  }
-
-  /* Force datagrid rows to match the same height */
-  .calendarContainer :global(.fc-datagrid-body tr) {
-    height: 30px !important;
-  }
-
-  .calendarContainer :global(.fc-datagrid-cell) {
-    height: 30px !important;
-  }
-
-  .calendarContainer :global(.fc-datagrid-cell-frame) {
-    height: 30px !important;
-  }
-
-  .calendarContainer :global(.fc-datagrid-cell-cushion) {
-    height: 30px !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-  }
-
-
-  /* Override timeline header row heights - REDUCED FOR MOBILE */
-  .calendarContainer :global(.fc-timeline-header-row) {
-    height: 24px !important;
-    min-height: 24px !important;
-    max-height: 24px !important;
-  }
-
-  /* Target the actual TR element in the scrollgrid */
-  .calendarContainer :global(.fc-scrollgrid-sync-table tbody tr) {
-    height: 24px !important;
-  }
-
-  /* Target header tbody specifically */
-  .calendarContainer :global(.fc-scrollgrid-section-header tbody tr) {
-    height: 24px !important;
-  }
-
-  /* Target all TDs in the header row */
-  .calendarContainer :global(.fc-scrollgrid-section-header tbody tr td) {
-    height: 24px !important;
-    padding: 0 !important;
-  }
-
-  /* Target the scrollgrid sync inner that controls heights */
-  .calendarContainer :global(.fc-scrollgrid-section-header .fc-scrollgrid-sync-inner) {
-    height: 24px !important;
-    min-height: 24px !important;
-    max-height: 24px !important;
-  }
-
-  /* Override the scroller element if it exists */
-  .calendarContainer :global(.fc-scrollgrid-section-header .fc-scroller) {
-    height: 24px !important;
-    overflow: hidden !important;
-  }
-
-  /* Target table element directly in header */
-  .calendarContainer :global(.fc-scrollgrid-section-header table) {
-    height: 24px !important;
-  }
-
-  /* Force all nested divs in header cells to be 24px */
-  .calendarContainer :global(.fc-scrollgrid-section-header td > div) {
-    height: 24px !important;
-    max-height: 24px !important;
-  }
-
-  /* Override timeline slot labels in header - SMALLER ON MOBILE */
-  .calendarContainer :global(.fc-timeline-slot-label) {
-    height: 24px !important;
-    line-height: 24px !important;
-    padding: 0 !important;
-  }
-
-  /* Specifically target the datagrid cells in the timeline header - COMPACT */
-  .calendarContainer :global(.fc-timeline-header .fc-datagrid-cell-frame) {
-    height: 24px !important;
-    min-height: 24px !important;
-    max-height: 24px !important;
-  }
-
-  /* Override inline styles on datagrid cell frames in header */
-  .calendarContainer :global(.fc-scrollgrid-section-header .fc-datagrid-cell-frame[style]) {
-    height: 24px !important;
-  }
-
-  /* Override inline styles on timeline slot frames in header */
-  .calendarContainer :global(.fc-scrollgrid-section-header .fc-timeline-slot-frame[style]) {
-    height: 24px !important;
-  }
-
-  /* Also target timeline slots in the header row */
-  .calendarContainer :global(.fc-timeline-header .fc-timeline-slot-frame[style]) {
-    height: 24px !important;
-  }
-
-
-  /* Override the datagrid header table that has inline style */
-  .calendarContainer :global(.fc-datagrid-header) {
-    width: auto !important;
-    height: 24px !important;
-    max-height: 24px !important;
-  }
-
-  /* Target the sync table in the header */
-  .calendarContainer :global(.fc-datagrid-header.fc-scrollgrid-sync-table) {
-    height: 24px !important;
-    max-height: 24px !important;
-  }
-
-  /* Override header table height */
-  .calendarContainer :global(table.fc-datagrid-header) {
-    height: 24px !important;
-  }
-
-  /* Force the header row in resource column to match */
-  .calendarContainer :global(.fc-datagrid-header tr) {
-    height: 24px !important;
-  }
-
-  .calendarContainer :global(.fc-datagrid-header td) {
-    height: 24px !important;
-    padding: 0 !important;
-  }
-
-  /* Also target the row element in the header */
-  .calendarContainer :global(.fc-timeline-header tr) {
-    height: 24px !important;
-  }
-
-  /* Override the timeline slot cushion - COMPACT FOR MOBILE */
-  .calendarContainer :global(.fc-timeline-slot-cushion) {
-    height: 24px !important;
-    min-height: 24px !important;
-    max-height: 24px !important;
-    padding: 0 2px !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-  }
-
-  /* Also target the scrollgrid sync inner elements - COMPACT */
-  .calendarContainer :global(.fc-scrollgrid-sync-inner) {
-    height: 24px !important;
-    min-height: 24px !important;
-    max-height: 24px !important;
-  }
-
-  /* Reduce font size for time labels on mobile */
-  .calendarContainer :global(.fc-timeline-header .fc-timeline-slot-label) {
-    font-size: 9px !important;
-    font-weight: 500 !important;
-  }
-
-  /* Ensure the timeline header container is compact */
-  .calendarContainer :global(.fc-timeline-header) {
-    height: 24px !important;
-  }
-
-  /* Compact the timeline header table cells */
-  .calendarContainer :global(.fc-timeline-header td) {
-    height: 24px !important;
-    padding: 0 !important;
-  }
-
-  /* Make the entire scrollgrid header compact */
-  .calendarContainer :global(.fc-scrollgrid-section-header) {
-    height: 24px !important;
-  }
-
-  /* Remove gap between header and body sections */
-  .calendarContainer :global(.fc-scrollgrid-section) {
-    border: none !important;
-  }
-
-  .calendarContainer :global(.fc-scrollgrid-section-body) {
-    border-top: none !important;
-  }
-
-  .calendarContainer :global(.fc-timeline .fc-scrollgrid-section > td) {
-    border: none !important;
-  }
-
-  /* Remove any margins/padding that create gaps */
-  .calendarContainer :global(.fc-timeline-body) {
-    margin-top: 0 !important;
-    padding-top: 0 !important;
-  }
-
-  .calendarContainer :global(.fc-datagrid-body) {
-    margin-top: 0 !important;
-    padding-top: 0 !important;
-  }
-
-  /* Remove border spacing and collapse borders on tables */
-  .calendarContainer :global(.fc-scrollgrid) {
-    border-spacing: 0 !important;
-    border-collapse: collapse !important;
-  }
-
-  .calendarContainer :global(.fc-scrollgrid table) {
-    border-spacing: 0 !important;
-    border-collapse: collapse !important;
-  }
-
-  /* Remove any top border from the first body row */
-  .calendarContainer :global(.fc-scrollgrid-section-body tr:first-child td) {
-    border-top: none !important;
-  }
-
-  .calendarContainer :global(.fc-timeline-body tr:first-child td) {
-    border-top: none !important;
-  }
-
-  /* Make the resource column (table numbers) narrower on mobile */
-  .calendarContainer :global(.fc-resource-timeline colgroup col:first-child) {
-    width: 40px !important;
-    max-width: 40px !important;
-  }
-
-  /* Make the resource timeline divider column specifically 3px */
-  .calendarContainer :global(colgroup col:nth-child(2)) {
-    width: 3px !important;
-    min-width: 3px !important;
-    max-width: 3px !important;
-  }
-
-  /* Also ensure the td cell containing the divider is thin */
-  .calendarContainer :global(td.fc-resource-timeline-divider) {
-    width: 3px !important;
-    min-width: 3px !important;
-    max-width: 3px !important;
-    padding: 0 !important;
-    height: auto !important;
-  }
-
-  /* Fix divider header cell */
-  .calendarContainer :global(.fc-timeline-header td.fc-resource-timeline-divider) {
-    height: 24px !important;
-    vertical-align: top !important;
-  }
-
-  /* Ensure divider doesn't create gaps */
-  .calendarContainer :global(.fc-resource-timeline-divider .fc-datagrid-cell-frame) {
-    height: 24px !important;
-    padding: 0 !important;
-    border: none !important;
-  }
-
-  /* Make table numbers same font size as reservations on mobile */
   .calendarContainer :global(.fc-datagrid-cell-main) {
-    font-size: 10px !important;
+    font-size: 10px;
   }
 
-  /* Also target the resource cell text specifically */
-  .calendarContainer :global(.fc-resource-timeline .fc-datagrid-cell) {
-    font-size: 10px !important;
-  }
-
-  /* Remove height overrides on mobile to allow JS sync */
-  /* The datagrid cells should match timeline naturally */
-  .calendarContainer :global(.fc-datagrid-body .fc-datagrid-cell-cushion) {
-    padding: 8px 2px !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
+  /* Prevent scroll snap-back */
+  .calendarContainer :global(.fc-scroller) {
+    overscroll-behavior-x: contain;
   }
 }
-
-


### PR DESCRIPTION
## Summary
- Fixed mobile horizontal scrolling issue on the reservations timeline at /admin/reservations
- Users can now properly scroll horizontally to view all time slots (not just snap to start/end)

## Problem
The timeline on mobile would only show the earliest or latest time, with no ability to scroll to times in between. This was caused by CSS overrides fighting with FullCalendar's internal JavaScript scrolling mechanism.

## Solution
- Removed 200+ lines of CSS height overrides that were breaking FullCalendar's row synchronization
- Eliminated forced overflow behaviors that conflicted with touch scrolling
- Let FullCalendar handle its native scrolling instead of fighting it with CSS
- Kept minimal configuration for proper mobile display

## Changes
- `src/components/ReservationsTimeline.tsx`: Minor config adjustments
- `src/styles/ReservationsTimeline.module.css`: Removed problematic height/overflow overrides (reduced from 660 to ~440 lines)

## Test Plan
- [ ] Open /admin/reservations on mobile device or mobile view
- [ ] Verify horizontal scrolling works smoothly across all time slots
- [ ] Check that timeline rows stay synchronized when scrolling
- [ ] Confirm desktop view still works properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)