### PR TITLE
Fix: Approve/Save button hidden on mobile in reservation edit modal

### DIFF
--- a/src/components/ReservationEditModal.tsx
+++ b/src/components/ReservationEditModal.tsx
@@ -498,8 +498,8 @@ const ReservationEditModal: React.FC<ReservationEditModalProps> = ({
           boxShadow: '0 4px 24px rgba(0, 0, 0, 0.15)',
           maxWidth: isMobile ? '100%' : '600px',
           width: isMobile ? '100vw' : '100%',
-          maxHeight: isMobile ? '100vh' : '90vh',
-          height: isMobile ? '100vh' : 'auto',
+          maxHeight: isMobile ? 'calc(100 * var(--vh, 1vh))' : '90vh',
+          height: isMobile ? 'calc(100 * var(--vh, 1vh))' : 'auto',
           display: 'flex',
           flexDirection: 'column',
           position: 'relative',
@@ -604,7 +604,7 @@ const ReservationEditModal: React.FC<ReservationEditModalProps> = ({
         </div>
 
         {/* Body */}
-        <div style={{ padding: isMobile ? '1rem' : '1.5rem', overflowY: 'auto', flex: 1, maxHeight: isMobile ? 'calc(100vh - 140px)' : 'auto' }}>
+        <div style={{ padding: isMobile ? '1rem' : '1.5rem', overflowY: 'auto', flex: 1, maxHeight: isMobile ? 'calc(100 * var(--vh, 1vh) - 140px)' : 'auto' }}>
           {isLoading ? (
             <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '200px' }}>
               <div style={{ fontSize: '0.875rem', color: '#6B7280' }}>Loading...</div>
@@ -941,7 +941,7 @@ const ReservationEditModal: React.FC<ReservationEditModalProps> = ({
         </div>
 
         {/* Footer */}
-        <div style={{ borderTop: '1px solid #D1D5DB', padding: isMobile ? '1rem' : '1rem 1.5rem', display: 'flex', flexDirection: isMobile ? 'column' : 'row', justifyContent: 'space-between', alignItems: isMobile ? 'stretch' : 'center', gap: isMobile ? '0.5rem' : '0' }}>
+        <div style={{ borderTop: '1px solid #D1D5DB', padding: isMobile ? '1rem 1rem calc(1rem + env(safe-area-inset-bottom, 0px)) 1rem' : '1rem 1.5rem', display: 'flex', flexDirection: isMobile ? 'column' : 'row', justifyContent: 'space-between', alignItems: isMobile ? 'stretch' : 'center', gap: isMobile ? '0.5rem' : '0', flexShrink: 0 }}>
           {isConfirmingDelete ? (
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' }}>
               <p style={{ fontWeight: '600', fontSize: '0.875rem', color: '#1F1F1F', margin: 0 }}>Are you sure?</p>


### PR DESCRIPTION
## Summary
- Fixes #45: the Save/Approve button in the reservation edit modal (`ReservationEditModal.tsx`) was pushed off-screen on mobile because the modal used a hardcoded `100vh`, which doesn't account for the mobile browser's address bar.
- Switched to the app's existing `--vh` custom property (already used elsewhere in `globals.css`/ViewportHeightProvider to fix the same class of bug for Chakra drawers), and added safe-area-inset padding to the footer.

## Test plan
- [ ] Open /admin/reservations on a real mobile device (or DevTools device emulation with the address bar visible)
- [ ] Tap a reservation to open the edit modal
- [ ] Confirm the Save button is visible/tappable without needing to guess/scroll past the fold
- [ ] Confirm desktop behavior is unchanged

Closes #45

🤖 Generated with [Claude Code](https://claude.ai/code)
