### PR TITLE
Mobile: full parity for campaign create/edit flow (shadcn/ui port)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,6 +62,20 @@
   }
 }
 
+/* Caps full-screen Sheet panels to the real visible viewport height so they
+   never overflow below the fold on iOS Safari when the address bar is
+   showing (same class of bug fixed for drawers in #45/#47). Falls back to
+   the JS-computed --vh unit on browsers without dvh support. */
+.sheet-dvh-max-height {
+  max-height: calc(100 * var(--vh));
+}
+
+@supports (height: 100dvh) {
+  .sheet-dvh-max-height {
+    max-height: 100dvh;
+  }
+}
+
 /* Mobile-specific CSS reset to override browser defaults */
 * {
   box-sizing: border-box;

--- a/src/components/CampaignDrawer.tsx
+++ b/src/components/CampaignDrawer.tsx
@@ -1,39 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import {
-  Drawer,
-  DrawerBody,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerOverlay,
-  DrawerContent,
-  DrawerCloseButton,
-  Button,
-  VStack,
-  HStack,
-  FormControl,
-  FormLabel,
-  Input,
-  Textarea,
-  Select,
-  Switch,
-  Text,
-  useToast,
-  Box,
-  Checkbox,
-  CheckboxGroup,
-  Stack,
-  NumberInput,
-  NumberInputField,
-  NumberInputStepper,
-  NumberIncrementStepper,
-  NumberDecrementStepper,
-  Radio,
-  RadioGroup,
-  Divider,
-  Badge,
-  IconButton,
-} from '@chakra-ui/react';
-import { CloseIcon, CalendarIcon } from '@chakra-ui/icons';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Select } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Separator } from '@/components/ui/separator';
+import { useToast } from '@/hooks/useToast';
 
 interface Campaign {
   id?: string;
@@ -65,6 +40,18 @@ interface CampaignDrawerProps {
   onCampaignUpdated: () => void;
 }
 
+const RECURRING_SCHEDULE_OPTIONS = [
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'monthly', label: 'Monthly' },
+  { value: 'yearly', label: 'Yearly' },
+  { value: 'weekdays', label: 'Specific Weekdays' },
+  { value: 'first_of_month', label: '1st of Month' },
+  { value: 'last_of_month', label: 'Last Day of Month' },
+];
+
+const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
 const CampaignDrawer: React.FC<CampaignDrawerProps> = ({
   isOpen,
   onClose,
@@ -85,7 +72,7 @@ const CampaignDrawer: React.FC<CampaignDrawerProps> = ({
   const [locations, setLocations] = useState<any[]>([]);
   const [selectedLocationIds, setSelectedLocationIds] = useState<string[]>([]);
   const [appliesToAllLocations, setAppliesToAllLocations] = useState(false);
-  const toast = useToast();
+  const { toast } = useToast();
 
   // Initialization effect: runs when drawer opens or mode/campaign changes
   useEffect(() => {
@@ -122,7 +109,7 @@ const CampaignDrawer: React.FC<CampaignDrawerProps> = ({
 
   const fetchCampaign = async () => {
     if (!campaignId) return;
-    
+
     setIsLoading(true);
     try {
       const response = await fetch(`/api/campaigns/${campaignId}`);
@@ -218,211 +205,193 @@ const CampaignDrawer: React.FC<CampaignDrawerProps> = ({
     { value: 'reservation_time', label: 'Reservation Time' },
   ];
 
+  const toggleWeekday = (value: string) => {
+    const current: string[] = formData.recurring_schedule?.weekdays || [];
+    const next = current.includes(value)
+      ? current.filter(v => v !== value)
+      : [...current, value];
+    handleInputChange('recurring_schedule', { ...formData.recurring_schedule, weekdays: next });
+  };
+
+  const toggleLocation = (locationId: string) => {
+    setSelectedLocationIds(prev =>
+      prev.includes(locationId) ? prev.filter(id => id !== locationId) : [...prev, locationId]
+    );
+  };
+
   const renderTriggerTypeSpecificFields = () => {
     switch (formData.trigger_type) {
       case 'recurring':
         return (
-          <VStack spacing={4} align="stretch">
-            <FormControl>
-              <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">
-                Recurring Schedule
-              </FormLabel>
-              <RadioGroup value={formData.recurring_schedule?.type || 'weekly'} onChange={(value) => handleInputChange('recurring_schedule', { ...formData.recurring_schedule, type: value })}>
-                <Stack direction="column">
-                  <Radio value="daily" colorScheme="green">Daily</Radio>
-                  <Radio value="weekly" colorScheme="green">Weekly</Radio>
-                  <Radio value="monthly" colorScheme="green">Monthly</Radio>
-                  <Radio value="yearly" colorScheme="green">Yearly</Radio>
-                  <Radio value="weekdays" colorScheme="green">Specific Weekdays</Radio>
-                  <Radio value="first_of_month" colorScheme="green">1st of Month</Radio>
-                  <Radio value="last_of_month" colorScheme="green">Last Day of Month</Radio>
-                </Stack>
-              </RadioGroup>
-            </FormControl>
+          <div className="flex flex-col gap-4">
+            <div>
+              <Label className="text-[#a59480]">Recurring Schedule</Label>
+              <div className="mt-2 flex flex-col gap-2">
+                {RECURRING_SCHEDULE_OPTIONS.map(option => (
+                  <label key={option.value} className="flex items-center gap-2 text-sm text-[#353535]">
+                    <input
+                      type="radio"
+                      name="recurring_schedule_type"
+                      className="h-4 w-4 accent-green-600"
+                      checked={(formData.recurring_schedule?.type || 'weekly') === option.value}
+                      onChange={() => handleInputChange('recurring_schedule', { ...formData.recurring_schedule, type: option.value })}
+                    />
+                    {option.label}
+                  </label>
+                ))}
+              </div>
+            </div>
 
-            {(formData.recurring_schedule?.type === 'weekdays') && (
-              <FormControl>
-                <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">
-                  Select Weekdays
-                </FormLabel>
-                <CheckboxGroup value={formData.recurring_schedule?.weekdays || []} onChange={(value) => handleInputChange('recurring_schedule', { ...formData.recurring_schedule, weekdays: value })}>
-                  <Stack direction="column">
-                    <Checkbox value="0">Sunday</Checkbox>
-                    <Checkbox value="1">Monday</Checkbox>
-                    <Checkbox value="2">Tuesday</Checkbox>
-                    <Checkbox value="3">Wednesday</Checkbox>
-                    <Checkbox value="4">Thursday</Checkbox>
-                    <Checkbox value="5">Friday</Checkbox>
-                    <Checkbox value="6">Saturday</Checkbox>
-                  </Stack>
-                </CheckboxGroup>
-              </FormControl>
+            {formData.recurring_schedule?.type === 'weekdays' && (
+              <div>
+                <Label className="text-[#a59480]">Select Weekdays</Label>
+                <div className="mt-2 flex flex-col gap-2">
+                  {WEEKDAYS.map((day, index) => (
+                    <label key={day} className="flex items-center gap-2 text-sm text-[#353535]">
+                      <Checkbox
+                        checked={(formData.recurring_schedule?.weekdays || []).includes(String(index))}
+                        onCheckedChange={() => toggleWeekday(String(index))}
+                      />
+                      {day}
+                    </label>
+                  ))}
+                </div>
+              </div>
             )}
 
-            <HStack spacing={4}>
-              <FormControl>
-                <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">
-                  Start Date
-                </FormLabel>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <Label className="text-[#a59480]">Start Date</Label>
                 <Input
                   type="date"
                   value={formData.recurring_start_date || ''}
                   onChange={(e) => handleInputChange('recurring_start_date', e.target.value)}
-                  borderColor="#a59480"
-                  _focus={{ borderColor: '#8a7a66', boxShadow: '0 0 0 1px #8a7a66' }}
+                  className="mt-1"
                 />
-              </FormControl>
+              </div>
 
-              <FormControl>
-                <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">
-                  End Date (Optional)
-                </FormLabel>
+              <div>
+                <Label className="text-[#a59480]">End Date (Optional)</Label>
                 <Input
                   type="date"
                   value={formData.recurring_end_date || ''}
                   onChange={(e) => handleInputChange('recurring_end_date', e.target.value)}
-                  borderColor="#a59480"
-                  _focus={{ borderColor: '#8a7a66', boxShadow: '0 0 0 1px #8a7a66' }}
+                  className="mt-1"
                 />
-              </FormControl>
-            </HStack>
-          </VStack>
+              </div>
+            </div>
+          </div>
         );
 
       case 'reservation_range':
         return (
-          <VStack spacing={4} align="stretch">
-            <HStack spacing={4}>
-              <FormControl>
-                <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">
-                  Start Date & Time
-                </FormLabel>
-                <Input
-                  type="datetime-local"
-                  value={formData.reservation_range_start || ''}
-                  onChange={(e) => handleInputChange('reservation_range_start', e.target.value)}
-                  borderColor="#a59480"
-                  _focus={{ borderColor: '#8a7a66', boxShadow: '0 0 0 1px #8a7a66' }}
-                />
-              </FormControl>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label className="text-[#a59480]">Start Date &amp; Time</Label>
+              <Input
+                type="datetime-local"
+                value={formData.reservation_range_start || ''}
+                onChange={(e) => handleInputChange('reservation_range_start', e.target.value)}
+                className="mt-1"
+              />
+            </div>
 
-              <FormControl>
-                <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">
-                  End Date & Time
-                </FormLabel>
-                <Input
-                  type="datetime-local"
-                  value={formData.reservation_range_end || ''}
-                  onChange={(e) => handleInputChange('reservation_range_end', e.target.value)}
-                  borderColor="#a59480"
-                  _focus={{ borderColor: '#8a7a66', boxShadow: '0 0 0 1px #8a7a66' }}
-                />
-              </FormControl>
-            </HStack>
-          </VStack>
+            <div>
+              <Label className="text-[#a59480]">End Date &amp; Time</Label>
+              <Input
+                type="datetime-local"
+                value={formData.reservation_range_end || ''}
+                onChange={(e) => handleInputChange('reservation_range_end', e.target.value)}
+                className="mt-1"
+              />
+            </div>
+          </div>
         );
 
       case 'private_event':
         return (
-          <VStack spacing={4} align="stretch">
-            <FormControl>
-              <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">
-                Select Private Event
-              </FormLabel>
-              <Select
-                value={formData.selected_private_event_id || ''}
-                onChange={(e) => handleInputChange('selected_private_event_id', e.target.value)}
-                borderColor="#a59480"
-                _focus={{ borderColor: '#8a7a66', boxShadow: '0 0 0 1px #8a7a66' }}
-                placeholder="Select a private event"
-              >
-                {privateEvents.map((event) => (
-                  <option key={event.id} value={event.id}>
-                    {event.title} - {new Date(event.start_time).toLocaleDateString()}
-                  </option>
-                ))}
-              </Select>
-            </FormControl>
-          </VStack>
+          <div>
+            <Label className="text-[#a59480]">Select Private Event</Label>
+            <Select
+              value={formData.selected_private_event_id || ''}
+              onChange={(e) => handleInputChange('selected_private_event_id', e.target.value)}
+              className="mt-1"
+            >
+              <option value="" disabled>Select a private event</option>
+              {privateEvents.map((event) => (
+                <option key={event.id} value={event.id}>
+                  {event.title} - {new Date(event.start_time).toLocaleDateString()}
+                </option>
+              ))}
+            </Select>
+          </div>
         );
 
       case 'all_members':
         return (
-          <VStack spacing={4} align="stretch">
-            <FormControl display="flex" alignItems="center">
-              <FormLabel htmlFor="include-event-list" mb="0" fontFamily="'Montserrat', sans-serif" color="#a59480">
-                Include Event List
-              </FormLabel>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="include-event-list" className="text-[#a59480]">Include Event List</Label>
               <Switch
                 id="include-event-list"
-                isChecked={formData.include_event_list || false}
-                onChange={(e) => handleInputChange('include_event_list', e.target.checked)}
-                colorScheme="green"
+                checked={formData.include_event_list || false}
+                onCheckedChange={(checked) => handleInputChange('include_event_list', checked)}
               />
-            </FormControl>
-            
+            </div>
+
             {formData.include_event_list && (
-              <VStack spacing={4} align="stretch">
-                <FormControl>
-                  <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Event Date Range</FormLabel>
+              <div className="flex flex-col gap-4">
+                <div>
+                  <Label className="text-[#a59480]">Event Date Range</Label>
                   <Select
                     value={formData.event_list_date_range?.type || 'this_month'}
-                    onChange={(e) => handleInputChange('event_list_date_range', { 
-                      ...formData.event_list_date_range, 
-                      type: e.target.value 
+                    onChange={(e) => handleInputChange('event_list_date_range', {
+                      ...formData.event_list_date_range,
+                      type: e.target.value
                     })}
-                    bg="#ecede8"
-                    color="#353535"
-                    borderColor="#a59480"
-                    _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
+                    className="mt-1"
                   >
                     <option value="this_month">This Month</option>
                     <option value="next_month">Next Month</option>
                     <option value="specific_range">Specific Date Range</option>
                   </Select>
-                </FormControl>
+                </div>
 
                 {formData.event_list_date_range?.type === 'specific_range' && (
-                  <HStack spacing={4}>
-                    <FormControl>
-                      <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Start Date</FormLabel>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <Label className="text-[#a59480]">Start Date</Label>
                       <Input
                         type="date"
                         value={formData.event_list_date_range?.start_date || ''}
-                        onChange={(e) => handleInputChange('event_list_date_range', { 
-                          ...formData.event_list_date_range, 
-                          start_date: e.target.value 
+                        onChange={(e) => handleInputChange('event_list_date_range', {
+                          ...formData.event_list_date_range,
+                          start_date: e.target.value
                         })}
-                        bg="#ecede8"
-                        color="#353535"
-                        borderColor="#a59480"
-                        _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
+                        className="mt-1"
                       />
-                    </FormControl>
-                    <FormControl>
-                      <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">End Date</FormLabel>
+                    </div>
+                    <div>
+                      <Label className="text-[#a59480]">End Date</Label>
                       <Input
                         type="date"
                         value={formData.event_list_date_range?.end_date || ''}
-                        onChange={(e) => handleInputChange('event_list_date_range', { 
-                          ...formData.event_list_date_range, 
-                          end_date: e.target.value 
+                        onChange={(e) => handleInputChange('event_list_date_range', {
+                          ...formData.event_list_date_range,
+                          end_date: e.target.value
                         })}
-                        bg="#ecede8"
-                        color="#353535"
-                        borderColor="#a59480"
-                        _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
+                        className="mt-1"
                       />
-                    </FormControl>
-                  </HStack>
+                    </div>
+                  </div>
                 )}
 
-                <Text fontSize="sm" color="#a59480">
+                <p className="text-sm text-[#a59480]">
                   Will include all "Noir Member Event" events within the selected date range.
-                </Text>
-              </VStack>
+                </p>
+              </div>
             )}
-          </VStack>
+          </div>
         );
 
       default:
@@ -505,100 +474,54 @@ const CampaignDrawer: React.FC<CampaignDrawerProps> = ({
   };
 
   return (
-    <Drawer
-      isOpen={isOpen}
-      placement="right"
-      onClose={onClose}
-      size="lg"
-    >
-      <DrawerOverlay />
-      <DrawerContent
-        borderLeft="2px solid #a59480"
-        borderRadius="0 0 0 20px"
-        fontFamily="'Montserrat', sans-serif"
-        maxW="600px"
-        w="100%"
-        boxShadow="0 0 50px rgba(0,0,0,0.3)"
-        mt="60px"
-        mb="20px"
-        padding="0"
-        backgroundColor="#f8f9fa"
-        position="relative"
-        transform="translateX(0)"
-        transition="all 0.3s ease"
+    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-lg flex flex-col p-0 border-l-2 border-l-[#a59480] font-montserrat"
       >
-        <DrawerHeader
-          borderBottom="2px solid #ecede8"
-          backgroundColor="#ecede8"
-          color="#353535"
-          fontFamily="'IvyJournal', serif"
-          fontSize="2xl"
-          fontWeight="bold"
-          py={6}
-        >
-          <HStack justify="space-between">
-            <Text>{isCreateMode ? 'Create New Campaign' : 'Edit Campaign'}</Text>
-            <DrawerCloseButton
-              color="#a59480"
-              _hover={{ color: '#8a7a66' }}
-              size="lg"
-            />
-          </HStack>
-        </DrawerHeader>
+        <SheetHeader className="shrink-0 border-b-2 border-[#ecede8] bg-[#ecede8] px-6 py-4 text-left">
+          <SheetTitle className="font-ivyjournal text-2xl font-bold text-[#353535]">
+            {isCreateMode ? 'Create New Campaign' : 'Edit Campaign'}
+          </SheetTitle>
+        </SheetHeader>
 
-        <DrawerBody py={8} overflowY="auto" maxH="calc(100vh - 200px)">
+        <div className="flex-1 overflow-y-auto min-h-0 px-6 py-8">
           {isLoading ? (
-            <Box textAlign="center" py={12}>
-              <Text>Loading campaign...</Text>
-            </Box>
+            <div className="py-12 text-center text-[#353535]">Loading campaign...</div>
           ) : (
-            <VStack spacing={6} align="stretch">
+            <div className="flex flex-col gap-6">
               {/* Basic Information */}
-              <Box>
-                <Text fontSize="lg" fontWeight="bold" color="#353535" mb={4}>
-                  Campaign Information
-                </Text>
-                
-                <VStack spacing={4} align="stretch">
-                  <FormControl>
-                    <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">
-                      Campaign Name *
-                    </FormLabel>
+              <div>
+                <h3 className="mb-4 text-lg font-bold text-[#353535]">Campaign Information</h3>
+
+                <div className="flex flex-col gap-4">
+                  <div>
+                    <Label className="text-[#a59480]">Campaign Name *</Label>
                     <Input
                       value={formData.name}
                       onChange={(e) => handleInputChange('name', e.target.value)}
                       placeholder="Enter campaign name"
-                      borderColor="#a59480"
-                      _focus={{ borderColor: '#8a7a66', boxShadow: '0 0 0 1px #8a7a66' }}
-                      fontFamily="'Montserrat', sans-serif"
+                      className="mt-1"
                     />
-                  </FormControl>
+                  </div>
 
-                  <FormControl>
-                    <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">
-                      Description
-                    </FormLabel>
+                  <div>
+                    <Label className="text-[#a59480]">Description</Label>
                     <Textarea
                       value={formData.description}
                       onChange={(e) => handleInputChange('description', e.target.value)}
                       placeholder="Enter campaign description"
-                      borderColor="#a59480"
-                      _focus={{ borderColor: '#8a7a66', boxShadow: '0 0 0 1px #8a7a66' }}
-                      fontFamily="'Montserrat', sans-serif"
                       rows={3}
+                      className="mt-1"
                     />
-                  </FormControl>
+                  </div>
 
-                  <FormControl>
-                    <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">
-                      Trigger Type *
-                    </FormLabel>
+                  <div>
+                    <Label className="text-[#a59480]">Trigger Type *</Label>
                     <Select
                       value={formData.trigger_type}
                       onChange={(e) => handleInputChange('trigger_type', e.target.value)}
-                      borderColor="#a59480"
-                      _focus={{ borderColor: '#8a7a66', boxShadow: '0 0 0 1px #8a7a66' }}
-                      fontFamily="'Montserrat', sans-serif"
+                      className="mt-1"
                     >
                       {getTriggerTypeOptions().map((option) => (
                         <option key={option.value} value={option.value}>
@@ -606,125 +529,97 @@ const CampaignDrawer: React.FC<CampaignDrawerProps> = ({
                         </option>
                       ))}
                     </Select>
-                  </FormControl>
-                </VStack>
-              </Box>
+                  </div>
+                </div>
+              </div>
 
               {/* Trigger Type Specific Fields */}
               {formData.trigger_type && (
                 <>
-                  <Divider borderColor="#a59480" />
-                  <Box>
-                    <Text fontSize="lg" fontWeight="bold" color="#353535" mb={4}>
+                  <Separator className="bg-[#a59480]" />
+                  <div>
+                    <h3 className="mb-4 text-lg font-bold text-[#353535]">
                       {formData.trigger_type === 'recurring' && 'Recurring Schedule'}
                       {formData.trigger_type === 'reservation_range' && 'Reservation Range'}
                       {formData.trigger_type === 'private_event' && 'Private Event Selection'}
                       {formData.trigger_type === 'all_members' && 'All Members Options'}
-                    </Text>
+                    </h3>
                     {renderTriggerTypeSpecificFields()}
-                  </Box>
+                  </div>
                 </>
               )}
 
               {/* Location Assignment */}
-              <Divider borderColor="#a59480" />
-              <Box>
-                <Text fontSize="lg" fontWeight="bold" color="#353535" mb={4}>
-                  Locations
-                </Text>
-                <VStack align="stretch" spacing={4}>
-                  <FormControl display="flex" alignItems="center">
-                    <FormLabel htmlFor="all-locations" mb="0" fontFamily="'Montserrat', sans-serif" color="#a59480">
-                      Apply to all locations
-                    </FormLabel>
+              <Separator className="bg-[#a59480]" />
+              <div>
+                <h3 className="mb-4 text-lg font-bold text-[#353535]">Locations</h3>
+                <div className="flex flex-col gap-4">
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="all-locations" className="text-[#a59480]">Apply to all locations</Label>
                     <Switch
                       id="all-locations"
-                      isChecked={appliesToAllLocations}
-                      onChange={(e) => setAppliesToAllLocations(e.target.checked)}
-                      colorScheme="green"
+                      checked={appliesToAllLocations}
+                      onCheckedChange={(checked) => setAppliesToAllLocations(checked)}
                     />
-                  </FormControl>
+                  </div>
 
                   {!appliesToAllLocations && (
-                    <CheckboxGroup
-                      value={selectedLocationIds}
-                      onChange={(values) => setSelectedLocationIds(values as string[])}
-                    >
-                      <Stack spacing={2}>
-                        {locations.map((location) => (
+                    <div className="flex flex-col gap-2">
+                      {locations.map((location) => (
+                        <label key={location.id} className="flex items-center gap-2 text-[#353535]">
                           <Checkbox
-                            key={location.id}
-                            value={location.id}
-                            fontFamily="'Montserrat', sans-serif"
-                            color="#353535"
-                          >
-                            {location.name}
-                          </Checkbox>
-                        ))}
-                      </Stack>
-                    </CheckboxGroup>
+                            checked={selectedLocationIds.includes(location.id)}
+                            onCheckedChange={() => toggleLocation(location.id)}
+                          />
+                          {location.name}
+                        </label>
+                      ))}
+                    </div>
                   )}
-                </VStack>
-              </Box>
+                </div>
+              </div>
 
               {/* Status */}
-              <Divider borderColor="#a59480" />
-              <Box>
-                <Text fontSize="lg" fontWeight="bold" color="#353535" mb={4}>
-                  Status
-                </Text>
-                <HStack spacing={4} align="center">
-                  <Button
-                    size="sm"
-                    colorScheme={formData.is_active ? 'green' : 'red'}
-                    variant="outline"
-                    onClick={() => handleInputChange('is_active', !formData.is_active)}
-                    fontFamily="'Montserrat', sans-serif"
-                    fontWeight="bold"
-                    _hover={{
-                      transform: 'translateY(-1px)',
-                      boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-                    }}
-                  >
-                    {formData.is_active ? 'Active' : 'Inactive'}
-                  </Button>
-                </HStack>
-              </Box>
-            </VStack>
+              <Separator className="bg-[#a59480]" />
+              <div>
+                <h3 className="mb-4 text-lg font-bold text-[#353535]">Status</h3>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => handleInputChange('is_active', !formData.is_active)}
+                  className={formData.is_active
+                    ? 'border-green-600 text-green-700 hover:bg-green-600 hover:text-white'
+                    : 'border-red-600 text-red-700 hover:bg-red-600 hover:text-white'}
+                >
+                  {formData.is_active ? 'Active' : 'Inactive'}
+                </Button>
+              </div>
+            </div>
           )}
-        </DrawerBody>
+        </div>
 
-        <DrawerFooter>
-          <HStack spacing={4} w="full">
-            <Button
-              variant="outline"
-              onClick={onClose}
-              flex={1}
-              fontFamily="'Montserrat', sans-serif"
-              borderColor="#353535"
-              color="#353535"
-              _hover={{ bg: '#f0f0f0' }}
-            >
-              Cancel
-            </Button>
-            <Button
-              colorScheme="blue"
-              onClick={handleSave}
-              isLoading={isSaving}
-              loadingText="Saving..."
-              flex={1}
-              fontFamily="'Montserrat', sans-serif"
-              bg="#a59480"
-              color="#ECEDE8"
-              _hover={{ bg: '#8a7a6a' }}
-            >
-              {isCreateMode ? 'Create Campaign' : 'Update Campaign'}
-            </Button>
-          </HStack>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+        <SheetFooter className="shrink-0 flex-row gap-3 border-t border-[#ecede8] bg-white px-6 py-4 pb-[calc(1rem+env(safe-area-inset-bottom))] sm:justify-end sm:space-x-0">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            className="min-h-[44px] flex-1 border-[#353535] text-[#353535] hover:bg-[#f0f0f0]"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={isSaving}
+            className="min-h-[44px] flex-1 bg-[#a59480] text-[#ECEDE8] hover:bg-[#8a7a6a]"
+          >
+            {isSaving ? 'Saving...' : (isCreateMode ? 'Create Campaign' : 'Update Campaign')}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
   );
 };
 
-export default CampaignDrawer; 
+export default CampaignDrawer;

--- a/src/components/CampaignDrawer.tsx
+++ b/src/components/CampaignDrawer.tsx
@@ -477,10 +477,15 @@ const CampaignDrawer: React.FC<CampaignDrawerProps> = ({
     <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <SheetContent
         side="right"
-        className="w-full sm:max-w-lg flex flex-col p-0 border-l-2 border-l-[#a59480] font-montserrat"
+        overlayClassName="bg-black/70"
+        className="sheet-dvh-max-height flex w-full flex-col overflow-hidden rounded-[10px] border-2 border-[#353535] bg-[#ecede8] p-0 sm:max-w-lg"
+        style={{ fontFamily: 'Montserrat, sans-serif' }}
       >
-        <SheetHeader className="shrink-0 border-b-2 border-[#ecede8] bg-[#ecede8] px-6 py-4 text-left">
-          <SheetTitle className="font-ivyjournal text-2xl font-bold text-[#353535]">
+        <SheetHeader className="shrink-0 border-b p-4 pb-2 pt-3 text-left">
+          <SheetTitle
+            className="text-xl font-bold text-[#353535]"
+            style={{ fontFamily: 'IvyJournal, sans-serif' }}
+          >
             {isCreateMode ? 'Create New Campaign' : 'Edit Campaign'}
           </SheetTitle>
         </SheetHeader>
@@ -599,7 +604,7 @@ const CampaignDrawer: React.FC<CampaignDrawerProps> = ({
           )}
         </div>
 
-        <SheetFooter className="shrink-0 flex-row gap-3 border-t border-[#ecede8] bg-white px-6 py-4 pb-[calc(1rem+env(safe-area-inset-bottom))] sm:justify-end sm:space-x-0">
+        <SheetFooter className="shrink-0 flex-row gap-3 border-t px-6 py-4 pb-[calc(1rem+env(safe-area-inset-bottom))] sm:justify-end sm:space-x-0">
           <Button
             type="button"
             variant="outline"

--- a/src/components/CampaignTemplateDrawer.tsx
+++ b/src/components/CampaignTemplateDrawer.tsx
@@ -1,50 +1,25 @@
 import React, { useState, useEffect } from 'react';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from '@/components/ui/sheet';
 import {
-  Drawer,
-  DrawerBody,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerOverlay,
-  DrawerContent,
-  Button,
-  VStack,
-  HStack,
-  FormControl,
-  FormLabel,
-  Input,
-  Select,
-  Textarea,
-  Text,
-  Box,
-  Divider,
-  useToast,
-  Spinner,
-  Badge,
-  IconButton,
-  Switch,
-  Alert,
-  AlertIcon,
-  NumberInput,
-  NumberInputField,
-  NumberInputStepper,
-  NumberIncrementStepper,
-  NumberDecrementStepper,
-  Radio,
-  RadioGroup,
-  Stack,
-  Checkbox,
-  CheckboxGroup,
   AlertDialog,
-  AlertDialogBody,
-  AlertDialogFooter,
-  AlertDialogHeader,
   AlertDialogContent,
-  AlertDialogOverlay,
-  useDisclosure,
-} from '@chakra-ui/react';
-import { CloseIcon, DeleteIcon } from '@chakra-ui/icons';
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Select } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Separator } from '@/components/ui/separator';
+import { Spinner } from '@/components/ui/spinner';
+import { Info } from 'lucide-react';
 import { useSettings } from '../context/SettingsContext';
-import { InfoIcon } from '@chakra-ui/icons';
+import { useToast } from '@/hooks/useToast';
 import { CampaignTriggerType } from '../types';
 
 interface CampaignTemplate {
@@ -96,6 +71,8 @@ interface CampaignTemplateDrawerProps {
   campaignTriggerType?: CampaignTriggerType;
 }
 
+const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
 const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
   isOpen,
   onClose,
@@ -106,7 +83,6 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
   isCampaignMode = false,
   campaignTriggerType,
 }) => {
-  const cancelRef = React.useRef<HTMLButtonElement>(null);
   const [template, setTemplate] = useState<CampaignTemplate | null>(null);
   const [formData, setFormData] = useState({
     campaign_id: '',
@@ -147,7 +123,7 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
   const [isLoadingPrivateEvents, setIsLoadingPrivateEvents] = useState(false);
   const [campaignData, setCampaignData] = useState<any>(null);
   const [noirMemberEvents, setNoirMemberEvents] = useState<any[]>([]);
-  const toast = useToast();
+  const { toast } = useToast();
   const { settings } = useSettings();
 
   useEffect(() => {
@@ -180,10 +156,10 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
           // New fields for reservation range campaigns
           reservation_range_include_past: true,
           reservation_range_minute_precision: false,
-                  // New fields for private event campaigns
-        private_event_date_range: undefined,
-        private_event_include_old: false,
-        selected_private_event_id: undefined,
+          // New fields for private event campaigns
+          private_event_date_range: undefined,
+          private_event_include_old: false,
+          selected_private_event_id: undefined,
         });
         setTemplate(null);
         setShowPreview(false);
@@ -210,7 +186,7 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
 
   const fetchTemplate = async () => {
     if (!templateId) return;
-    
+
     setIsLoading(true);
     try {
       const response = await fetch(`/api/campaign-messages/${templateId}`);
@@ -266,7 +242,7 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
       toast({
         title: 'Error',
         description: 'Failed to fetch template',
-        variant: 'destructive',
+        status: 'error',
       });
     } finally {
       setIsLoading(false);
@@ -283,23 +259,23 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
         const sortedEvents = (data.data || []).sort((a: any, b: any) => {
           const dateA = new Date(a.start_time);
           const dateB = new Date(b.start_time);
-          
+
           // First sort by date
           if (dateA.getTime() !== dateB.getTime()) {
             return dateA.getTime() - dateB.getTime();
           }
-          
+
           // If dates are the same, sort by name
           return a.title.localeCompare(b.title);
         });
-        
+
         setPrivateEvents(sortedEvents);
       } else {
         console.error('Failed to fetch private events');
         toast({
           title: 'Error',
           description: 'Failed to fetch private events',
-          variant: 'destructive',
+          status: 'error',
         });
       }
     } catch (error) {
@@ -307,7 +283,7 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
       toast({
         title: 'Error',
         description: 'Failed to fetch private events',
-        variant: 'destructive',
+        status: 'error',
       });
     } finally {
       setIsLoadingPrivateEvents(false);
@@ -316,14 +292,14 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
 
   const fetchCampaignData = async () => {
     if (!campaignId) return;
-    
+
     try {
       // Fetch campaign data
       const campaignResponse = await fetch(`/api/campaigns/${campaignId}`);
       if (campaignResponse.ok) {
         const campaignData = await campaignResponse.json();
         setCampaignData(campaignData);
-        
+
         // If campaign has event list enabled, fetch noir member events
         if (campaignData.include_event_list && campaignData.event_list_date_range) {
           await fetchNoirMemberEvents(campaignData.event_list_date_range);
@@ -350,19 +326,18 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 
-  const handleSave = async () => {
-    console.log('=== SAVING MESSAGE TEMPLATE ===');
-    console.log('Form data:', formData);
-    console.log('Campaign ID:', campaignId);
-    console.log('Is create mode:', isCreateMode);
-    console.log('Template ID:', templateId);
+  const toggleWeekday = (day: number) => {
+    const current = formData.recurring_weekdays || [];
+    const next = current.includes(day) ? current.filter(d => d !== day) : [...current, day];
+    handleInputChange('recurring_weekdays', next);
+  };
 
+  const handleSave = async () => {
     if (!formData.name.trim() || !formData.content.trim()) {
-      console.log('Validation failed: Missing required fields');
       toast({
         title: 'Validation Error',
         description: 'Please fill in all required fields',
-        variant: 'destructive',
+        status: 'error',
       });
       return;
     }
@@ -373,25 +348,25 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
       toast({
         title: 'Validation Error',
         description: `Recipient type "${formData.recipient_type}" is not valid for ${campaignTriggerType} campaigns. Please select a valid recipient type.`,
-        variant: 'destructive',
+        status: 'error',
       });
       return;
     }
 
     setIsSaving(true);
     try {
-      const url = isCreateMode 
-        ? '/api/campaign-messages' 
+      const url = isCreateMode
+        ? '/api/campaign-messages'
         : `/api/campaign-messages/${templateId}`;
-      
+
       const method = isCreateMode ? 'POST' : 'PUT';
-      
+
       // Clean up the data to only send relevant fields based on timing type
       let cleanedData: any = { ...formData };
-      
+
       // Remove trigger_type as it's not in the database schema
       delete cleanedData.trigger_type;
-      
+
       // Send all relevant fields including the new timing fields
       const basicFields = [
         'campaign_id', 'name', 'description', 'content', 'recipient_type',
@@ -401,23 +376,19 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
         'relative_time', 'relative_quantity', 'relative_unit', 'relative_proximity',
         'include_ledger_pdf', 'is_active', 'selected_private_event_id'
       ];
-      
+
       // Remove all fields except the basic ones
       Object.keys(cleanedData).forEach(key => {
         if (!basicFields.includes(key)) {
           delete cleanedData[key];
         }
       });
-      
+
       // If creating a template within a campaign, set the campaign_id
-      const dataToSend = isCreateMode && campaignId 
+      const dataToSend = isCreateMode && campaignId
         ? { ...cleanedData, campaign_id: campaignId }
         : cleanedData;
-      
-      console.log('Sending request to:', url);
-      console.log('Request method:', method);
-      console.log('Request data:', dataToSend);
-      
+
       const response = await fetch(url, {
         method,
         headers: {
@@ -426,22 +397,14 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
         body: JSON.stringify(dataToSend),
       });
 
-      console.log('Response status:', response.status);
-      console.log('Response ok:', response.ok);
-
       if (!response.ok) {
         const errorText = await response.text();
         console.error('Response error:', errorText);
         throw new Error(`Failed to save template: ${response.status} ${response.statusText}`);
       }
 
-      const responseData = await response.json();
-      console.log('Response data:', responseData);
+      await response.json();
 
-      console.log('=== MESSAGE TEMPLATE SAVED SUCCESSFULLY ===');
-      console.log('Template will be processed by cron job every 10 minutes');
-      console.log('Next processing time:', new Date(Date.now() + 10 * 60 * 1000).toLocaleString());
-      
       // If this is an all_members campaign and campaign data has been modified, save the campaign
       if (campaignTriggerType === 'all_members' && campaignId && campaignData) {
         try {
@@ -458,19 +421,15 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
 
           if (!campaignResponse.ok) {
             console.error('Failed to update campaign event list settings');
-            // Show warning to user but don't fail the entire save
             toast({
               title: 'Warning',
               description: 'Message saved but campaign settings update failed. Please try updating campaign settings separately.',
               status: 'warning',
               duration: 5000,
             });
-          } else {
-            console.log('Campaign event list settings updated successfully');
           }
         } catch (error) {
           console.error('Error updating campaign event list settings:', error);
-          // Show warning to user but don't fail the entire save
           toast({
             title: 'Warning',
             description: 'Message saved but campaign settings update encountered an error. Please try updating campaign settings separately.',
@@ -479,7 +438,7 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
           });
         }
       }
-      
+
       toast({
         title: 'Success',
         description: `Message ${isCreateMode ? 'created' : 'updated'} successfully`,
@@ -494,7 +453,7 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
       toast({
         title: 'Error',
         description: 'Failed to save template',
-        variant: 'destructive',
+        status: 'error',
       });
     } finally {
       setIsSaving(false);
@@ -529,7 +488,7 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
       toast({
         title: 'Error',
         description: 'Failed to delete template',
-        variant: 'destructive',
+        status: 'error',
       });
     } finally {
       setIsSaving(false);
@@ -543,31 +502,31 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
       .replace(/\{\{member_name\}\}/g, 'John Doe')
       .replace(/\{\{phone\}\}/g, '(555) 123-4567')
       .replace(/\{\{email\}\}/g, 'john.doe@example.com');
-    
+
     // Add reservation-specific placeholders if this is a reservation campaign
     if (campaignTriggerType === 'reservation' || campaignTriggerType === 'reservation_time' || campaignTriggerType === 'reservation_created') {
       previewContent = previewContent
         .replace(/\{\{reservation_time\}\}/g, '7:30 PM')
         .replace(/\{\{party_size\}\}/g, '4');
     }
-    
+
     // Add event list if this is an all_members campaign with event list enabled
     if (campaignTriggerType === 'all_members' && campaignData?.include_event_list && noirMemberEvents.length > 0) {
       const eventList = noirMemberEvents.map(event => {
         let eventLine = `• ${event.date} at ${event.time} - ${event.title}`;
-        
+
         // Add RSVP URL if available
         if (event.rsvpEnabled && event.rsvpUrl) {
           const rsvpUrl = `${window.location.origin}/rsvp/${event.rsvpUrl}`;
           eventLine += `\n  RSVP: ${rsvpUrl}`;
         }
-        
+
         return eventLine;
       }).join('\n\n');
-      
+
       previewContent += '\n\n📅 Upcoming Noir Member Events:\n' + eventList;
     }
-    
+
     return previewContent;
   };
 
@@ -604,21 +563,21 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
   const formatPhoneNumber = (phone: string) => {
     // Remove all non-digits
     const digits = phone.replace(/\D/g, '');
-    
+
     // Format as (XXX) XXX-XXXX
     if (digits.length === 10) {
       return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
     } else if (digits.length === 11 && digits.startsWith('1')) {
       return `(${digits.slice(1, 4)}) ${digits.slice(4, 7)}-${digits.slice(7)}`;
     }
-    
+
     return phone;
   };
 
   const handlePhoneChange = (phone: string) => {
     // Remove all non-digits
     const digits = phone.replace(/\D/g, '');
-    
+
     // Convert to international format for storage
     let formattedPhone = phone;
     if (digits.length === 10) {
@@ -628,7 +587,7 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
     } else {
       formattedPhone = '+' + digits;
     }
-    
+
     setFormData(prev => ({ ...prev, specific_phone: formattedPhone }));
   };
 
@@ -694,29 +653,9 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
     }
   };
 
-  const getTimingOptions = () => {
-    if (!campaignTriggerType) return ['specific_time', 'recurring', 'relative'];
-    
-    switch (campaignTriggerType) {
-      case 'recurring':
-        return ['specific_time', 'recurring', 'relative'];
-      
-      case 'all_members':
-        return ['specific_time', 'recurring', 'relative'];
-      
-      case 'reservation_range':
-      case 'private_event':
-        return ['specific_time', 'recurring', 'relative'];
-      
-      default:
-        // member_signup, member_birthday, member_renewal, reservation_time, reservation_created
-        return ['specific_time', 'recurring', 'relative'];
-    }
-  };
-
   const shouldShowRelativeOption = () => {
     if (!campaignTriggerType) return false;
-    
+
     // Only show relative option for triggers that have specific dates/times
     return ['member_signup', 'member_birthday', 'reservation_time', 'reservation_created', 'private_event'].includes(campaignTriggerType);
   };
@@ -734,228 +673,160 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
       { name: '{{event_date}}', description: 'Private event date' },
       { name: '{{event_time}}', description: 'Private event time' },
     ];
-    
+
     return placeholders;
   };
 
   const shouldShowLedgerPdfOption = () => {
     if (!campaignTriggerType) return false;
-    
+
     // Only show ledger PDF for member-related triggers
     return ['member_signup', 'member_birthday', 'member_renewal'].includes(campaignTriggerType);
   };
 
   return (
-    <Drawer 
-      isOpen={isOpen} 
-      placement="right" 
-      onClose={onClose} 
-      size="sm"
-      closeOnOverlayClick={true}
-      closeOnEsc={true}
-    >
-      <Box zIndex="2000" position="relative">
-        <DrawerOverlay bg="blackAlpha.600" onClick={onClose} />
-        <DrawerContent 
-          border="2px solid #353535" 
-          borderRadius="10px"  
-          fontFamily="Montserrat, sans-serif" 
-          maxW="500px" 
-          w="50vw" 
-          boxShadow="xl" 
-          mt="80px" 
-          mb="25px" 
-          paddingRight="40px" 
-          paddingLeft="40px" 
-          backgroundColor="#ecede8"
-          position="fixed"
-          top="0"
-          right="0"
-          style={{
-            transform: isOpen ? 'translateX(0)' : 'translateX(100%)',
-            transition: 'transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
-            willChange: 'transform',
-            transformStyle: 'preserve-3d',
-            backfaceVisibility: 'hidden'
-          }}
-        >
-          <DrawerHeader borderBottomWidth="1px" margin="0" fontWeight="bold" paddingTop="0px" fontSize="24px" fontFamily="IvyJournal, sans-serif" color="#353535">
-            <HStack justify="space-between" align="center">
-              <Text>
-                {isCreateMode ? 'Create/Edit Message' : 'Edit Message'}
-              </Text>
-              <IconButton
-                aria-label="Close drawer"
-                icon={<CloseIcon />}
-                size="sm"
-                variant="ghost"
-                bg="#353535"
-                onClick={onClose}
-                color="#ECEDE8"
-                _hover={{ bg: '#2a2a2a' }}
-              />
-            </HStack>
-          </DrawerHeader>
+    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-lg flex flex-col p-0 border-l-2 border-l-[#353535] font-montserrat"
+      >
+        <SheetHeader className="shrink-0 border-b px-6 py-4 text-left">
+          <SheetTitle className="font-ivyjournal text-2xl font-bold text-[#353535]">
+            {isCreateMode ? 'Create/Edit Message' : 'Edit Message'}
+          </SheetTitle>
+        </SheetHeader>
 
-          <DrawerBody className="drawer-body-content" overflowY="auto" maxH="calc(100vh - 200px)">
-            {isLoading ? (
-              <Box display="flex" justifyContent="center" alignItems="center" height="200px">
-                <Spinner size="xl" color="#a59480" />
-              </Box>
-            ) : (
-              <VStack spacing={6} align="stretch">
-                {/* Basic Information */}
-                <Box>
-                  <Text fontSize="lg" fontWeight="bold" mb={4} fontFamily="'Montserrat', sans-serif" color="#a59480">
-                    Basic Information
-                  </Text>
-                  <VStack spacing={4}>
-                    <FormControl>
-                      <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Template Name</FormLabel>
-                      <Input
-                        value={formData.name}
-                        onChange={(e) => handleInputChange('name', e.target.value)}
-                        bg="#ecede8"
-                        color="#353535"
-                        borderColor="#a59480"
-                        _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                      />
-                    </FormControl>
+        <div className="flex-1 overflow-y-auto min-h-0 px-4 py-6 md:px-6">
+          {isLoading ? (
+            <div className="flex h-[200px] items-center justify-center">
+              <Spinner size="lg" className="text-[#a59480]" />
+            </div>
+          ) : (
+            <div className="flex flex-col gap-6">
+              {/* Basic Information */}
+              <div>
+                <h3 className="mb-4 text-lg font-bold text-[#a59480]">Basic Information</h3>
+                <div className="flex flex-col gap-4">
+                  <div>
+                    <Label className="text-[#a59480]">Template Name</Label>
+                    <Input
+                      value={formData.name}
+                      onChange={(e) => handleInputChange('name', e.target.value)}
+                      className="mt-1"
+                    />
+                  </div>
 
-                    <FormControl>
-                      <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Description</FormLabel>
-                      <Input
-                        value={formData.description}
-                        onChange={(e) => handleInputChange('description', e.target.value)}
-                        bg="#ecede8"
-                        color="#353535"
-                        borderColor="#a59480"
-                        _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                      />
-                    </FormControl>
-                  </VStack>
-                </Box>
+                  <div>
+                    <Label className="text-[#a59480]">Description</Label>
+                    <Input
+                      value={formData.description}
+                      onChange={(e) => handleInputChange('description', e.target.value)}
+                      className="mt-1"
+                    />
+                  </div>
+                </div>
+              </div>
 
-                <Divider borderColor="#a59480" />
+              <Separator className="bg-[#a59480]" />
 
-                {/* Recipient Configuration */}
-                <Box>
-                  <VStack spacing={4}>
-                    <FormControl>
-                      <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Recipient Type</FormLabel>
+              {/* Recipient Configuration */}
+              <div className="flex flex-col gap-4">
+                <div>
+                  <Label className="text-[#a59480]">Recipient Type</Label>
+                  <Select
+                    value={formData.recipient_type}
+                    onChange={(e) => handleInputChange('recipient_type', e.target.value)}
+                    className="mt-1"
+                  >
+                    {getRecipientOptions().map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+
+                {formData.recipient_type === 'specific_phone' && (
+                  <div>
+                    <Label className="text-[#a59480]">Phone Number</Label>
+                    <Input
+                      value={formatPhoneNumber(formData.specific_phone || '')}
+                      onChange={(e) => handlePhoneChange(e.target.value)}
+                      placeholder="(555) 123-4567"
+                      className="mt-1"
+                    />
+                    <p className="mt-1 text-xs text-[#a59480]">Format: (XXX) XXX-XXXX</p>
+                  </div>
+                )}
+
+                {formData.recipient_type === 'private_event_rsvps' && (
+                  <div>
+                    <Label className="text-[#a59480]">Select Private Event</Label>
+                    {isLoadingPrivateEvents ? (
+                      <div className="flex h-[100px] items-center justify-center">
+                        <Spinner size="md" className="text-[#a59480]" />
+                      </div>
+                    ) : (
                       <Select
-                        value={formData.recipient_type}
-                        onChange={(e) => handleInputChange('recipient_type', e.target.value)}
-                        bg="#ecede8"
-                        color="#353535"
-                        borderColor="#a59480"
-                        _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
+                        value={formData.selected_private_event_id || ''}
+                        onChange={(e) => handleInputChange('selected_private_event_id', e.target.value)}
+                        className="mt-1"
                       >
-                        {getRecipientOptions().map((option) => (
-                          <option key={option.value} value={option.value}>
-                            {option.label}
+                        <option value="">Select a private event</option>
+                        {privateEvents.map((event) => (
+                          <option key={event.id} value={event.id}>
+                            {new Date(event.start_time).toLocaleDateString()} {new Date(event.start_time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} - {event.title}
                           </option>
                         ))}
                       </Select>
-                    </FormControl>
-
-                    {formData.recipient_type === 'specific_phone' && (
-                      <FormControl>
-                        <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Phone Number</FormLabel>
-                        <Input
-                          value={formatPhoneNumber(formData.specific_phone || '')}
-                          onChange={(e) => handlePhoneChange(e.target.value)}
-                          bg="#ecede8"
-                          color="#353535"
-                          borderColor="#a59480"
-                          _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                          placeholder="(555) 123-4567"
-                        />
-                        <Text fontSize="xs" color="#a59480" mt={1}>
-                          Format: (XXX) XXX-XXXX
-                        </Text>
-                      </FormControl>
                     )}
-
-                    {formData.recipient_type === 'private_event_rsvps' && (
-                      <FormControl>
-                        <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Select Private Event</FormLabel>
-                        {isLoadingPrivateEvents ? (
-                          <Box display="flex" justifyContent="center" alignItems="center" height="100px">
-                            <Spinner size="md" color="#a59480" />
-                          </Box>
-                        ) : (
-                          <Select
-                            value={formData.selected_private_event_id || ''}
-                            onChange={(e) => handleInputChange('selected_private_event_id', e.target.value)}
-                            bg="#ecede8"
-                            color="#353535"
-                            borderColor="#a59480"
-                            _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                            placeholder="Select a private event"
-                          >
-                            <option value="">Select a private event</option>
-                            {privateEvents.map((event) => (
-                              <option key={event.id} value={event.id}>
-                                {new Date(event.start_time).toLocaleDateString()} {new Date(event.start_time).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})} - {event.title}
-                              </option>
-                            ))}
-                          </Select>
-                        )}
-                        {privateEvents.length === 0 && !isLoadingPrivateEvents && (
-                          <Text fontSize="xs" color="#a59480" mt={1}>
-                            No private events found. Create some private events first.
-                          </Text>
-                        )}
-                      </FormControl>
+                    {privateEvents.length === 0 && !isLoadingPrivateEvents && (
+                      <p className="mt-1 text-xs text-[#a59480]">
+                        No private events found. Create some private events first.
+                      </p>
                     )}
-                  </VStack>
-                </Box>
+                  </div>
+                )}
+              </div>
 
-                <Divider borderColor="#a59480" />
+              <Separator className="bg-[#a59480]" />
 
-                {/* Event List Configuration - Only for all_members campaigns */}
-                {campaignTriggerType === 'all_members' && (
-                  <Box>
-                    <Text fontSize="lg" fontWeight="bold" mb={4} fontFamily="'Montserrat', sans-serif" color="#a59480">
-                      Event List Configuration
-                    </Text>
-                    <VStack spacing={4}>
-                      <FormControl display="flex" alignItems="center">
-                        <FormLabel htmlFor="include-event-list" mb="0" fontFamily="'Montserrat', sans-serif" color="#a59480">
-                          Include Event List
-                        </FormLabel>
+              {/* Event List Configuration - Only for all_members campaigns */}
+              {campaignTriggerType === 'all_members' && (
+                <>
+                  <div>
+                    <h3 className="mb-4 text-lg font-bold text-[#a59480]">Event List Configuration</h3>
+                    <div className="flex flex-col gap-4">
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="include-event-list" className="text-[#a59480]">Include Event List</Label>
                         <Switch
                           id="include-event-list"
-                          isChecked={campaignData?.include_event_list || false}
-                          onChange={(e) => {
-                            // Update campaign data locally for preview
+                          checked={campaignData?.include_event_list || false}
+                          onCheckedChange={(checked) => {
                             setCampaignData(prev => ({
                               ...prev,
-                              include_event_list: e.target.checked,
-                              event_list_date_range: e.target.checked ? (prev?.event_list_date_range || { type: 'this_month' }) : null
+                              include_event_list: checked,
+                              event_list_date_range: checked ? (prev?.event_list_date_range || { type: 'this_month' }) : null
                             }));
-                            // If enabling, fetch events immediately
-                            if (e.target.checked) {
+                            if (checked) {
                               fetchNoirMemberEvents(campaignData?.event_list_date_range || { type: 'this_month' });
                             } else {
                               setNoirMemberEvents([]);
                             }
                           }}
-                          colorScheme="green"
                         />
-                      </FormControl>
-                      
+                      </div>
+
                       {campaignData?.include_event_list && (
-                        <VStack spacing={4} align="stretch">
-                          <FormControl>
-                            <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Event Date Range</FormLabel>
+                        <div className="flex flex-col gap-4">
+                          <div>
+                            <Label className="text-[#a59480]">Event Date Range</Label>
                             <Select
                               value={campaignData?.event_list_date_range?.type || 'this_month'}
                               onChange={(e) => {
-                                const newDateRange = { 
-                                  ...campaignData?.event_list_date_range, 
-                                  type: e.target.value 
+                                const newDateRange = {
+                                  ...campaignData?.event_list_date_range,
+                                  type: e.target.value
                                 };
                                 setCampaignData(prev => ({
                                   ...prev,
@@ -963,28 +834,25 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
                                 }));
                                 fetchNoirMemberEvents(newDateRange);
                               }}
-                              bg="#ecede8"
-                              color="#353535"
-                              borderColor="#a59480"
-                              _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
+                              className="mt-1"
                             >
                               <option value="this_month">This Month</option>
                               <option value="next_month">Next Month</option>
                               <option value="specific_range">Specific Date Range</option>
                             </Select>
-                          </FormControl>
+                          </div>
 
                           {campaignData?.event_list_date_range?.type === 'specific_range' && (
-                            <HStack spacing={4}>
-                              <FormControl>
-                                <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Start Date</FormLabel>
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                              <div>
+                                <Label className="text-[#a59480]">Start Date</Label>
                                 <Input
                                   type="date"
                                   value={campaignData?.event_list_date_range?.start_date || ''}
                                   onChange={(e) => {
-                                    const newDateRange = { 
-                                      ...campaignData?.event_list_date_range, 
-                                      start_date: e.target.value 
+                                    const newDateRange = {
+                                      ...campaignData?.event_list_date_range,
+                                      start_date: e.target.value
                                     };
                                     setCampaignData(prev => ({
                                       ...prev,
@@ -994,21 +862,18 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
                                       fetchNoirMemberEvents(newDateRange);
                                     }
                                   }}
-                                  bg="#ecede8"
-                                  color="#353535"
-                                  borderColor="#a59480"
-                                  _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
+                                  className="mt-1"
                                 />
-                              </FormControl>
-                              <FormControl>
-                                <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">End Date</FormLabel>
+                              </div>
+                              <div>
+                                <Label className="text-[#a59480]">End Date</Label>
                                 <Input
                                   type="date"
                                   value={campaignData?.event_list_date_range?.end_date || ''}
                                   onChange={(e) => {
-                                    const newDateRange = { 
-                                      ...campaignData?.event_list_date_range, 
-                                      end_date: e.target.value 
+                                    const newDateRange = {
+                                      ...campaignData?.event_list_date_range,
+                                      end_date: e.target.value
                                     };
                                     setCampaignData(prev => ({
                                       ...prev,
@@ -1018,554 +883,438 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
                                       fetchNoirMemberEvents(newDateRange);
                                     }
                                   }}
-                                  bg="#ecede8"
-                                  color="#353535"
-                                  borderColor="#a59480"
-                                  _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
+                                  className="mt-1"
                                 />
-                              </FormControl>
-                            </HStack>
+                              </div>
+                            </div>
                           )}
 
-                          <Text fontSize="sm" color="#a59480">
+                          <p className="text-sm text-[#a59480]">
                             Will include all "Noir Member Event" events within the selected date range.
-                          </Text>
-                        </VStack>
+                          </p>
+                        </div>
                       )}
-                    </VStack>
-                  </Box>
-                )}
+                    </div>
+                  </div>
+                  <Separator className="bg-[#a59480]" />
+                </>
+              )}
 
-                <Divider borderColor="#a59480" />
-
-                {/* Timing Configuration */}
-                <Box>
-                  <VStack spacing={4}>
-                    <FormControl>
-                      <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Timing Type</FormLabel>
-                      <RadioGroup value={formData.timing_type} onChange={(value) => handleInputChange('timing_type', value)}>
-                        <Stack direction="column">
-                          <Radio 
-                            value="specific_time" 
-                            colorScheme="green"
-                            bg={formData.timing_type === 'specific_time' ? '#ecede8' : 'transparent'}
-                            p={2}
-                            borderRadius="md"
-                            border={formData.timing_type === 'specific_time' ? '2px solid #a59480' : '1px solid transparent'}
-                          >
-                            Send at specific time
-                          </Radio>
-                          <Radio 
-                            value="recurring" 
-                            colorScheme="green"
-                            bg={formData.timing_type === 'recurring' ? '#ecede8' : 'transparent'}
-                            p={2}
-                            borderRadius="md"
-                            border={formData.timing_type === 'recurring' ? '2px solid #a59480' : '1px solid transparent'}
-                          >
-                            Send on recurring schedule
-                          </Radio>
-                          {shouldShowRelativeOption() && (
-                            <Radio 
-                              value="relative" 
-                              colorScheme="green"
-                              bg={formData.timing_type === 'relative' ? '#ecede8' : 'transparent'}
-                              p={2}
-                              borderRadius="md"
-                              border={formData.timing_type === 'relative' ? '2px solid #a59480' : '1px solid transparent'}
-                            >
-                              Send relative to trigger date
-                            </Radio>
-                          )}
-                        </Stack>
-                      </RadioGroup>
-                    </FormControl>
-
-                    {formData.timing_type === 'specific_time' && (
-                      <VStack spacing={4} width="100%">
-                        <HStack spacing={4} width="100%">
-                          <FormControl>
-                            <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Time</FormLabel>
-                            <Input
-                              type="time"
-                              value={formData.specific_time}
-                              onChange={(e) => handleInputChange('specific_time', e.target.value)}
-                              bg="#ecede8"
-                              color="#353535"
-                              borderColor="#a59480"
-                              _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                            />
-                          </FormControl>
-
-                          <FormControl>
-                            <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Date</FormLabel>
-                            <Input
-                              type="date"
-                              value={formData.specific_date}
-                              onChange={(e) => handleInputChange('specific_date', e.target.value)}
-                              bg="#ecede8"
-                              color="#353535"
-                              borderColor="#a59480"
-                              _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                            />
-                          </FormControl>
-                        </HStack>
-                      </VStack>
-                    )}
-
-                    {formData.timing_type === 'recurring' && (
-                      <VStack spacing={4} width="100%">
-                        <FormControl>
-                          <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Recurring Type</FormLabel>
-                          <RadioGroup value={formData.recurring_type} onChange={(value) => handleInputChange('recurring_type', value)}>
-                            <Stack direction="column">
-                              <Radio value="daily" colorScheme="green">Daily</Radio>
-                              <Radio value="weekly" colorScheme="green">Weekly</Radio>
-                              <Radio value="monthly" colorScheme="green">Monthly</Radio>
-                              <Radio value="yearly" colorScheme="green">Yearly</Radio>
-                            </Stack>
-                          </RadioGroup>
-                        </FormControl>
-
-                        <FormControl>
-                          <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Time</FormLabel>
-                          <Input
-                            type="time"
-                            value={formData.recurring_time || '10:00'}
-                            onChange={(e) => handleInputChange('recurring_time', e.target.value)}
-                            bg="#ecede8"
-                            color="#353535"
-                            borderColor="#a59480"
-                            _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                          />
-                        </FormControl>
-
-                        {formData.recurring_type === 'weekly' && (
-                          <FormControl>
-                            <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Select Weekdays</FormLabel>
-                            <CheckboxGroup value={formData.recurring_weekdays || []} onChange={(value) => handleInputChange('recurring_weekdays', value)}>
-                              <Stack direction="column">
-                                <Checkbox value="0">Sunday</Checkbox>
-                                <Checkbox value="1">Monday</Checkbox>
-                                <Checkbox value="2">Tuesday</Checkbox>
-                                <Checkbox value="3">Wednesday</Checkbox>
-                                <Checkbox value="4">Thursday</Checkbox>
-                                <Checkbox value="5">Friday</Checkbox>
-                                <Checkbox value="6">Saturday</Checkbox>
-                              </Stack>
-                            </CheckboxGroup>
-                          </FormControl>
-                        )}
-
-                        {formData.recurring_type === 'monthly' && (
-                          <>
-                            <FormControl>
-                              <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Monthly Type</FormLabel>
-                              <RadioGroup value={formData.recurring_monthly_type} onChange={(value) => handleInputChange('recurring_monthly_type', value)}>
-                                <Stack direction="column">
-                                  <Radio value="first" colorScheme="green">First</Radio>
-                                  <Radio value="second" colorScheme="green">Second</Radio>
-                                  <Radio value="third" colorScheme="green">Third</Radio>
-                                  <Radio value="fourth" colorScheme="green">Fourth</Radio>
-                                  <Radio value="last" colorScheme="green">Last</Radio>
-                                </Stack>
-                              </RadioGroup>
-                            </FormControl>
-
-                            <FormControl>
-                              <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Day/Weekday</FormLabel>
-                              <RadioGroup value={formData.recurring_monthly_day} onChange={(value) => handleInputChange('recurring_monthly_day', value)}>
-                                <Stack direction="column">
-                                  <Radio value="day" colorScheme="green">Day</Radio>
-                                  <Radio value="weekday" colorScheme="green">Weekday</Radio>
-                                </Stack>
-                              </RadioGroup>
-                            </FormControl>
-
-                            <FormControl>
-                              <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Value</FormLabel>
-                              <NumberInput
-                                value={formData.recurring_monthly_value || 1}
-                                onChange={(value) => handleInputChange('recurring_monthly_value', parseInt(value))}
-                                min={0}
-                                max={31}
-                                bg="#ecede8"
-                                color="#353535"
-                                borderColor="#a59480"
-                                _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                              >
-                                <NumberInputField 
-                                  placeholder="1-31"
-                                  _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                                />
-                                <NumberInputStepper>
-                                  <NumberIncrementStepper />
-                                  <NumberDecrementStepper />
-                                </NumberInputStepper>
-                              </NumberInput>
-                            </FormControl>
-                          </>
-                        )}
-
-                        {formData.recurring_type === 'yearly' && (
-                          <FormControl>
-                            <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Yearly Date</FormLabel>
-                            <Input
-                              type="date"
-                              value={formData.recurring_yearly_date || ''}
-                              onChange={(e) => handleInputChange('recurring_yearly_date', e.target.value)}
-                              bg="#ecede8"
-                              color="#353535"
-                              borderColor="#a59480"
-                              _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                            />
-                          </FormControl>
-                        )}
-                      </VStack>
-                    )}
-
-                    {formData.timing_type === 'relative' && (
-                      <VStack spacing={4} width="100%">
-                        <HStack spacing={4} width="100%">
-                          {formData.relative_unit !== 'minute' && (
-                            <FormControl>
-                              <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Time</FormLabel>
-                              <Input
-                                type="time"
-                                value={formData.relative_time || '10:00'}
-                                onChange={(e) => handleInputChange('relative_time', e.target.value)}
-                                bg="#ecede8"
-                                color="#353535"
-                                borderColor="#a59480"
-                                _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                              />
-                            </FormControl>
-                          )}
-
-                          <FormControl>
-                            <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Quantity</FormLabel>
-                            <NumberInput
-                              value={formData.relative_quantity ?? 1}
-                              onChange={(value) => handleInputChange('relative_quantity', parseInt(value))}
-                              min={0}
-                              max={formData.relative_unit === 'minute' ? 1440 : 365}
-                              bg="#ecede8"
-                              color="#353535"
-                              borderColor="#a59480"
-                              _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                            >
-                              <NumberInputField 
-                                placeholder={formData.relative_unit === 'minute' ? "1-1440" : "1-365"}
-                                _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                              />
-                              <NumberInputStepper>
-                                <NumberIncrementStepper />
-                                <NumberDecrementStepper />
-                              </NumberInputStepper>
-                            </NumberInput>
-                          </FormControl>
-
-                          <FormControl>
-                            <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Time Unit</FormLabel>
-                            <Select
-                              value={formData.relative_unit || 'day'}
-                              onChange={(e) => handleInputChange('relative_unit', e.target.value)}
-                              bg="#ecede8"
-                              color="#353535"
-                              borderColor="#a59480"
-                              _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                            >
-                              <option value="minute">Minutes</option>
-                              <option value="hour">Hours</option>
-                              <option value="day">Days</option>
-                              <option value="week">Weeks</option>
-                              <option value="month">Months</option>
-                              <option value="year">Years</option>
-                            </Select>
-                          </FormControl>
-
-                          <FormControl>
-                            <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">Proximity</FormLabel>
-                            <Select
-                              value={formData.relative_proximity || 'after'}
-                              onChange={(e) => handleInputChange('relative_proximity', e.target.value)}
-                              bg="#ecede8"
-                              color="#353535"
-                              borderColor="#a59480"
-                              _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                            >
-                              <option value="before">Before</option>
-                              <option value="after">After</option>
-                            </Select>
-                          </FormControl>
-                        </HStack>
-                      </VStack>
-                    )}
-
-                    <Box p={4} bg="#ecede8" borderRadius="md" border="1px solid #a59480">
-                      <Text fontFamily="'Montserrat', sans-serif" color="#353535" fontWeight="bold">
-                        {formatTimingDisplay()}
-                      </Text>
-                    </Box>
-                  </VStack>
-                </Box>
-
-                <Divider borderColor="#a59480" />
-
-                {/* Message Template */}
-                <Box>
-                  <VStack spacing={4}>
-                    <FormControl>
-                      <FormLabel fontFamily="'Montserrat', sans-serif" color="#a59480">
-                        Message Content
-                        <IconButton
-                          aria-label="View available placeholders"
-                          icon={<InfoIcon />}
-                          size="sm"
-                          variant="ghost"
-                          color="#a59480"
-                          ml={2}
-                          onClick={() => {
-                            const placeholders = getAvailablePlaceholders();
-                            const placeholderText = placeholders.map(p => `${p.name}: ${p.description}`).join('\n');
-                            alert(`Available Placeholders:\n\n${placeholderText}`);
-                          }}
+              {/* Timing Configuration */}
+              <div className="flex flex-col gap-4">
+                <div>
+                  <Label className="text-[#a59480]">Timing Type</Label>
+                  <div className="mt-2 flex flex-col gap-2">
+                    <label className={`flex items-center gap-2 rounded-md border p-2 text-sm text-[#353535] ${formData.timing_type === 'specific_time' ? 'border-2 border-[#a59480] bg-[#ecede8]' : 'border-transparent'}`}>
+                      <input
+                        type="radio"
+                        name="timing_type"
+                        className="h-4 w-4 accent-green-600"
+                        checked={formData.timing_type === 'specific_time'}
+                        onChange={() => handleInputChange('timing_type', 'specific_time')}
+                      />
+                      Send at specific time
+                    </label>
+                    <label className={`flex items-center gap-2 rounded-md border p-2 text-sm text-[#353535] ${formData.timing_type === 'recurring' ? 'border-2 border-[#a59480] bg-[#ecede8]' : 'border-transparent'}`}>
+                      <input
+                        type="radio"
+                        name="timing_type"
+                        className="h-4 w-4 accent-green-600"
+                        checked={formData.timing_type === 'recurring'}
+                        onChange={() => handleInputChange('timing_type', 'recurring')}
+                      />
+                      Send on recurring schedule
+                    </label>
+                    {shouldShowRelativeOption() && (
+                      <label className={`flex items-center gap-2 rounded-md border p-2 text-sm text-[#353535] ${formData.timing_type === 'relative' ? 'border-2 border-[#a59480] bg-[#ecede8]' : 'border-transparent'}`}>
+                        <input
+                          type="radio"
+                          name="timing_type"
+                          className="h-4 w-4 accent-green-600"
+                          checked={formData.timing_type === 'relative'}
+                          onChange={() => handleInputChange('timing_type', 'relative')}
                         />
-                      </FormLabel>
-                      <Textarea
-                        value={formData.content}
-                        onChange={(e) => handleInputChange('content', e.target.value)}
-                        rows={8}
-                        minH="200px"
-                        resize="vertical"
-                        bg="#ecede8"
-                        color="#353535"
-                        borderColor="#a59480"
-                        _focus={{ borderColor: '#a59480', boxShadow: '0 0 0 1px #a59480' }}
-                        placeholder="Enter your message template here. Use placeholders like {{first_name}}, {{last_name}}, etc."
-                        fontFamily="'Montserrat', sans-serif"
-                        fontSize="14px"
-                        lineHeight="1.5"
-                        w="90%"
-                      />
-                    </FormControl>
-
-                    {/* Preview Toggle */}
-                    <FormControl display="flex" alignItems="center">
-                      <FormLabel htmlFor="show-preview" mb="0" fontFamily="'Montserrat', sans-serif" color="#a59480">
-                        Show Preview
-                      </FormLabel>
-                      <Switch
-                        id="show-preview"
-                        isChecked={showPreview}
-                        onChange={(e) => setShowPreview(e.target.checked)}
-                        colorScheme="green"
-                      />
-                    </FormControl>
-
-                    {/* Preview Section */}
-                    {showPreview && formData.content && (
-                      <Box>
-                        <Text fontSize="sm" fontWeight="bold" mb={2} fontFamily="'Montserrat', sans-serif" color="#a59480">
-                          Preview:
-                        </Text>
-                        <Box 
-                          p={4} 
-                          bg="#ecede8" 
-                          borderRadius="md" 
-                          border="1px solid #a59480"
-                          minH="120px"
-                          maxH="200px"
-                          overflowY="auto"
-                          w="90%"
-                        >
-                          <Text 
-                            fontFamily="'Montserrat', sans-serif" 
-                            color="#353535" 
-                            whiteSpace="pre-wrap"
-                            fontSize="14px"
-                            lineHeight="1.5"
-                          >
-                            {getPreviewMessage()}
-                          </Text>
-                        </Box>
-                      </Box>
+                        Send relative to trigger date
+                      </label>
                     )}
+                  </div>
+                </div>
 
-                    {/* Event List Preview - Only for all_members campaigns with event list enabled */}
-                    {campaignTriggerType === 'all_members' && campaignData?.include_event_list && (
-                      <Box>
-                        <Text fontSize="sm" fontWeight="bold" mb={2} fontFamily="'Montserrat', sans-serif" color="#a59480">
-                          Event List Preview:
-                        </Text>
-                        <Box 
-                          p={4} 
-                          bg="#f0f8ff" 
-                          borderRadius="md" 
-                          border="1px solid #a59480"
-                          minH="100px"
-                          maxH="200px"
-                          overflowY="auto"
-                          w="90%"
-                        >
-                          {noirMemberEvents.length > 0 ? (
-                            <VStack spacing={2} align="stretch">
-                              {noirMemberEvents.map((event, index) => (
-                                <Box key={index} p={2} bg="white" borderRadius="sm" border="1px solid #e0e0e0">
-                                  <Text fontWeight="bold" fontSize="sm" color="#353535">
-                                    {event.title}
-                                  </Text>
-                                  <Text fontSize="xs" color="#666">
-                                    {event.date} at {event.time}
-                                  </Text>
-                                  {event.description && (
-                                    <Text fontSize="xs" color="#666" mt={1}>
-                                      {event.description}
-                                    </Text>
-                                  )}
-                                </Box>
-                              ))}
-                            </VStack>
-                          ) : (
-                            <Text fontSize="sm" color="#666" fontStyle="italic">
-                              No Noir Member Events found for the selected date range.
-                            </Text>
-                          )}
-                        </Box>
-                      </Box>
-                    )}
-                  </VStack>
-                </Box>
-
-                <Divider borderColor="#a59480" />
-
-                {/* Ledger PDF Option - Only for member-related triggers */}
-                {shouldShowLedgerPdfOption() && (
-                  <>
-                    <Button
-                      size="sm"
-                      colorScheme={formData.include_ledger_pdf ? 'green' : 'gray'}
-                      variant="outline"
-                      onClick={() => handleInputChange('include_ledger_pdf', !formData.include_ledger_pdf)}
-                      fontFamily="'Montserrat', sans-serif"
-                      fontWeight="bold"
-                      _hover={{
-                        transform: 'translateY(-1px)',
-                        boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-                      }}
-                    >
-                      {formData.include_ledger_pdf ? '✓ Include Ledger PDF' : 'Include Ledger PDF'}
-                    </Button>
-                    <Divider borderColor="#a59480" />
-                  </>
+                {formData.timing_type === 'specific_time' && (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <Label className="text-[#a59480]">Time</Label>
+                      <Input
+                        type="time"
+                        value={formData.specific_time}
+                        onChange={(e) => handleInputChange('specific_time', e.target.value)}
+                        className="mt-1"
+                      />
+                    </div>
+                    <div>
+                      <Label className="text-[#a59480]">Date</Label>
+                      <Input
+                        type="date"
+                        value={formData.specific_date}
+                        onChange={(e) => handleInputChange('specific_date', e.target.value)}
+                        className="mt-1"
+                      />
+                    </div>
+                  </div>
                 )}
 
-                {/* Status */}
-                <Box>
-                  <Text fontSize="lg" fontWeight="bold" mb={4} fontFamily="'Montserrat', sans-serif" color="#a59480">
-                    Status
-                  </Text>
-                  <HStack spacing={4} align="center">
-                    <Button
-                      size="sm"
-                      colorScheme={formData.is_active ? 'green' : 'red'}
-                      variant="outline"
-                      onClick={() => handleInputChange('is_active', !formData.is_active)}
-                      fontFamily="'Montserrat', sans-serif"
-                      fontWeight="bold"
-                      _hover={{
-                        transform: 'translateY(-1px)',
-                        boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-                      }}
-                    >
-                      {formData.is_active ? 'Active' : 'Inactive'}
-                    </Button>
-                  </HStack>
-                </Box>
+                {formData.timing_type === 'recurring' && (
+                  <div className="flex flex-col gap-4">
+                    <div>
+                      <Label className="text-[#a59480]">Recurring Type</Label>
+                      <div className="mt-2 flex flex-col gap-2">
+                        {(['daily', 'weekly', 'monthly', 'yearly'] as const).map(type => (
+                          <label key={type} className="flex items-center gap-2 text-sm capitalize text-[#353535]">
+                            <input
+                              type="radio"
+                              name="recurring_type"
+                              className="h-4 w-4 accent-green-600"
+                              checked={formData.recurring_type === type}
+                              onChange={() => handleInputChange('recurring_type', type)}
+                            />
+                            {type}
+                          </label>
+                        ))}
+                      </div>
+                    </div>
 
-                {/* Delete Section */}
-                {!isCreateMode && templateId && (
-                  <>
-                    <Divider borderColor="#a59480" />
-                    <Box>
-                      <Text fontSize="lg" fontWeight="bold" mb={4} fontFamily="'Montserrat', sans-serif" color="#ef4444">
-                        Danger Zone
-                      </Text>
-                      <Button
-                        colorScheme="red"
-                        variant="outline"
-                        onClick={() => setIsConfirmingDelete(true)}
-                        fontFamily="'Montserrat', sans-serif"
+                    <div>
+                      <Label className="text-[#a59480]">Time</Label>
+                      <Input
+                        type="time"
+                        value={formData.recurring_time || '10:00'}
+                        onChange={(e) => handleInputChange('recurring_time', e.target.value)}
+                        className="mt-1"
+                      />
+                    </div>
+
+                    {formData.recurring_type === 'weekly' && (
+                      <div>
+                        <Label className="text-[#a59480]">Select Weekdays</Label>
+                        <div className="mt-2 flex flex-col gap-2">
+                          {WEEKDAYS.map((day, index) => (
+                            <label key={day} className="flex items-center gap-2 text-sm text-[#353535]">
+                              <Checkbox
+                                checked={(formData.recurring_weekdays || []).includes(index)}
+                                onCheckedChange={() => toggleWeekday(index)}
+                              />
+                              {day}
+                            </label>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    {formData.recurring_type === 'monthly' && (
+                      <>
+                        <div>
+                          <Label className="text-[#a59480]">Monthly Type</Label>
+                          <div className="mt-2 flex flex-col gap-2">
+                            {(['first', 'second', 'third', 'fourth', 'last'] as const).map(type => (
+                              <label key={type} className="flex items-center gap-2 text-sm capitalize text-[#353535]">
+                                <input
+                                  type="radio"
+                                  name="recurring_monthly_type"
+                                  className="h-4 w-4 accent-green-600"
+                                  checked={formData.recurring_monthly_type === type}
+                                  onChange={() => handleInputChange('recurring_monthly_type', type)}
+                                />
+                                {type}
+                              </label>
+                            ))}
+                          </div>
+                        </div>
+
+                        <div>
+                          <Label className="text-[#a59480]">Day/Weekday</Label>
+                          <div className="mt-2 flex flex-col gap-2">
+                            {(['day', 'weekday'] as const).map(type => (
+                              <label key={type} className="flex items-center gap-2 text-sm capitalize text-[#353535]">
+                                <input
+                                  type="radio"
+                                  name="recurring_monthly_day"
+                                  className="h-4 w-4 accent-green-600"
+                                  checked={formData.recurring_monthly_day === type}
+                                  onChange={() => handleInputChange('recurring_monthly_day', type)}
+                                />
+                                {type}
+                              </label>
+                            ))}
+                          </div>
+                        </div>
+
+                        <div>
+                          <Label className="text-[#a59480]">Value</Label>
+                          <Input
+                            type="number"
+                            min={0}
+                            max={31}
+                            placeholder="1-31"
+                            value={formData.recurring_monthly_value ?? 1}
+                            onChange={(e) => handleInputChange('recurring_monthly_value', parseInt(e.target.value, 10))}
+                            className="mt-1"
+                          />
+                        </div>
+                      </>
+                    )}
+
+                    {formData.recurring_type === 'yearly' && (
+                      <div>
+                        <Label className="text-[#a59480]">Yearly Date</Label>
+                        <Input
+                          type="date"
+                          value={formData.recurring_yearly_date || ''}
+                          onChange={(e) => handleInputChange('recurring_yearly_date', e.target.value)}
+                          className="mt-1"
+                        />
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {formData.timing_type === 'relative' && (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {formData.relative_unit !== 'minute' && (
+                      <div>
+                        <Label className="text-[#a59480]">Time</Label>
+                        <Input
+                          type="time"
+                          value={formData.relative_time || '10:00'}
+                          onChange={(e) => handleInputChange('relative_time', e.target.value)}
+                          className="mt-1"
+                        />
+                      </div>
+                    )}
+
+                    <div>
+                      <Label className="text-[#a59480]">Quantity</Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        max={formData.relative_unit === 'minute' ? 1440 : 365}
+                        placeholder={formData.relative_unit === 'minute' ? '1-1440' : '1-365'}
+                        value={formData.relative_quantity ?? 1}
+                        onChange={(e) => handleInputChange('relative_quantity', parseInt(e.target.value, 10))}
+                        className="mt-1"
+                      />
+                    </div>
+
+                    <div>
+                      <Label className="text-[#a59480]">Time Unit</Label>
+                      <Select
+                        value={formData.relative_unit || 'day'}
+                        onChange={(e) => handleInputChange('relative_unit', e.target.value)}
+                        className="mt-1"
                       >
-                        Delete Template
-                      </Button>
-                    </Box>
-                  </>
-                )}
-              </VStack>
-            )}
-          </DrawerBody>
+                        <option value="minute">Minutes</option>
+                        <option value="hour">Hours</option>
+                        <option value="day">Days</option>
+                        <option value="week">Weeks</option>
+                        <option value="month">Months</option>
+                        <option value="year">Years</option>
+                      </Select>
+                    </div>
 
-          <DrawerFooter className="drawer-footer-content">
-            <HStack spacing={4} w="full">
-              <Button
-                variant="outline"
-                onClick={onClose}
-                flex={1}
-                fontFamily="'Montserrat', sans-serif"
-                borderColor="#353535"
-                color="#353535"
-                _hover={{ bg: '#f0f0f0' }}
-              >
-                Cancel
-              </Button>
-              <Button
-                colorScheme="blue"
-                onClick={handleSave}
-                isLoading={isSaving}
-                loadingText="Saving..."
-                flex={1}
-                fontFamily="'Montserrat', sans-serif"
-                bg="#a59480"
-                color="#ECEDE8"
-                _hover={{ bg: '#8a7a6a' }}
-              >
-                {isCreateMode ? 'Create Template' : 'Update Template'}
-              </Button>
-            </HStack>
-          </DrawerFooter>
-        </DrawerContent>
-      </Box>
+                    <div>
+                      <Label className="text-[#a59480]">Proximity</Label>
+                      <Select
+                        value={formData.relative_proximity || 'after'}
+                        onChange={(e) => handleInputChange('relative_proximity', e.target.value)}
+                        className="mt-1"
+                      >
+                        <option value="before">Before</option>
+                        <option value="after">After</option>
+                      </Select>
+                    </div>
+                  </div>
+                )}
+
+                <div className="rounded-md border border-[#a59480] bg-[#ecede8] p-4">
+                  <p className="font-bold text-[#353535]">{formatTimingDisplay()}</p>
+                </div>
+              </div>
+
+              <Separator className="bg-[#a59480]" />
+
+              {/* Message Template */}
+              <div className="flex flex-col gap-4">
+                <div>
+                  <Label className="flex items-center text-[#a59480]">
+                    Message Content
+                    <button
+                      type="button"
+                      aria-label="View available placeholders"
+                      className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded text-[#a59480] hover:bg-[#ecede8]"
+                      onClick={() => {
+                        const placeholders = getAvailablePlaceholders();
+                        const placeholderText = placeholders.map(p => `${p.name}: ${p.description}`).join('\n');
+                        alert(`Available Placeholders:\n\n${placeholderText}`);
+                      }}
+                    >
+                      <Info className="h-4 w-4" />
+                    </button>
+                  </Label>
+                  <Textarea
+                    value={formData.content}
+                    onChange={(e) => handleInputChange('content', e.target.value)}
+                    rows={8}
+                    placeholder="Enter your message template here. Use placeholders like {{first_name}}, {{last_name}}, etc."
+                    className="mt-1 min-h-[200px] w-full resize-y text-sm leading-relaxed"
+                  />
+                </div>
+
+                {/* Preview Toggle */}
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="show-preview" className="text-[#a59480]">Show Preview</Label>
+                  <Switch
+                    id="show-preview"
+                    checked={showPreview}
+                    onCheckedChange={(checked) => setShowPreview(checked)}
+                  />
+                </div>
+
+                {/* Preview Section */}
+                {showPreview && formData.content && (
+                  <div>
+                    <p className="mb-2 text-sm font-bold text-[#a59480]">Preview:</p>
+                    <div className="max-h-[200px] min-h-[120px] w-full overflow-y-auto rounded-md border border-[#a59480] bg-[#ecede8] p-4">
+                      <p className="whitespace-pre-wrap text-sm leading-relaxed text-[#353535]">
+                        {getPreviewMessage()}
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                {/* Event List Preview - Only for all_members campaigns with event list enabled */}
+                {campaignTriggerType === 'all_members' && campaignData?.include_event_list && (
+                  <div>
+                    <p className="mb-2 text-sm font-bold text-[#a59480]">Event List Preview:</p>
+                    <div className="max-h-[200px] min-h-[100px] w-full overflow-y-auto rounded-md border border-[#a59480] bg-[#f0f8ff] p-4">
+                      {noirMemberEvents.length > 0 ? (
+                        <div className="flex flex-col gap-2">
+                          {noirMemberEvents.map((event, index) => (
+                            <div key={index} className="rounded-sm border border-[#e0e0e0] bg-white p-2">
+                              <p className="text-sm font-bold text-[#353535]">{event.title}</p>
+                              <p className="text-xs text-[#666]">{event.date} at {event.time}</p>
+                              {event.description && (
+                                <p className="mt-1 text-xs text-[#666]">{event.description}</p>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-sm italic text-[#666]">
+                          No Noir Member Events found for the selected date range.
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <Separator className="bg-[#a59480]" />
+
+              {/* Ledger PDF Option - Only for member-related triggers */}
+              {shouldShowLedgerPdfOption() && (
+                <>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handleInputChange('include_ledger_pdf', !formData.include_ledger_pdf)}
+                    className={formData.include_ledger_pdf
+                      ? 'w-fit border-green-600 text-green-700 hover:bg-green-600 hover:text-white'
+                      : 'w-fit border-gray-400 text-gray-600 hover:bg-gray-400 hover:text-white'}
+                  >
+                    {formData.include_ledger_pdf ? '✓ Include Ledger PDF' : 'Include Ledger PDF'}
+                  </Button>
+                  <Separator className="bg-[#a59480]" />
+                </>
+              )}
+
+              {/* Status */}
+              <div>
+                <h3 className="mb-4 text-lg font-bold text-[#a59480]">Status</h3>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => handleInputChange('is_active', !formData.is_active)}
+                  className={formData.is_active
+                    ? 'border-green-600 text-green-700 hover:bg-green-600 hover:text-white'
+                    : 'border-red-600 text-red-700 hover:bg-red-600 hover:text-white'}
+                >
+                  {formData.is_active ? 'Active' : 'Inactive'}
+                </Button>
+              </div>
+
+              {/* Delete Section */}
+              {!isCreateMode && templateId && (
+                <>
+                  <Separator className="bg-[#a59480]" />
+                  <div>
+                    <h3 className="mb-4 text-lg font-bold text-red-500">Danger Zone</h3>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => setIsConfirmingDelete(true)}
+                      className="min-h-[44px] border-red-600 text-red-700 hover:bg-red-600 hover:text-white"
+                    >
+                      Delete Template
+                    </Button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        <SheetFooter className="shrink-0 flex-row gap-3 border-t bg-white px-4 py-4 pb-[calc(1rem+env(safe-area-inset-bottom))] md:px-6 sm:justify-end sm:space-x-0">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            className="min-h-[44px] flex-1 border-[#353535] text-[#353535] hover:bg-[#f0f0f0]"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={isSaving}
+            className="min-h-[44px] flex-1 bg-[#a59480] text-[#ECEDE8] hover:bg-[#8a7a6a]"
+          >
+            {isSaving ? 'Saving...' : (isCreateMode ? 'Create Template' : 'Update Template')}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
 
       {/* Delete Confirmation Dialog */}
-      <AlertDialog
-        isOpen={isConfirmingDelete}
-        onClose={() => setIsConfirmingDelete(false)}
-        leastDestructiveRef={cancelRef}
-      >
-        <AlertDialogOverlay>
-          <AlertDialogContent>
-            <AlertDialogHeader fontSize="lg" fontWeight="bold">
-              Delete Template
-            </AlertDialogHeader>
-
-            <AlertDialogBody>
+      <AlertDialog open={isConfirmingDelete} onOpenChange={setIsConfirmingDelete}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Template</AlertDialogTitle>
+            <AlertDialogDescription>
               Are you sure you want to delete this template? This action cannot be undone.
-            </AlertDialogBody>
-
-            <AlertDialogFooter>
-              <Button onClick={() => setIsConfirmingDelete(false)}>
-                Cancel
-              </Button>
-              <Button colorScheme="red" onClick={handleDelete} ml={3}>
-                Delete
-              </Button>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialogOverlay>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button type="button" variant="outline" onClick={() => setIsConfirmingDelete(false)} className="min-h-[44px]">
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleDelete} className="min-h-[44px] bg-red-600 text-white hover:bg-red-700">
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
       </AlertDialog>
-    </Drawer>
+    </Sheet>
   );
 };
 
-export default CampaignTemplateDrawer; 
+export default CampaignTemplateDrawer;

--- a/src/components/CampaignTemplateDrawer.tsx
+++ b/src/components/CampaignTemplateDrawer.tsx
@@ -688,10 +688,15 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
     <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <SheetContent
         side="right"
-        className="w-full sm:max-w-lg flex flex-col p-0 border-l-2 border-l-[#353535] font-montserrat"
+        overlayClassName="bg-black/70"
+        className="sheet-dvh-max-height flex w-full flex-col overflow-hidden rounded-[10px] border-2 border-[#353535] bg-[#ecede8] p-0 sm:max-w-lg"
+        style={{ fontFamily: 'Montserrat, sans-serif' }}
       >
-        <SheetHeader className="shrink-0 border-b px-6 py-4 text-left">
-          <SheetTitle className="font-ivyjournal text-2xl font-bold text-[#353535]">
+        <SheetHeader className="shrink-0 border-b p-4 pb-2 pt-3 text-left">
+          <SheetTitle
+            className="text-xl font-bold text-[#353535]"
+            style={{ fontFamily: 'IvyJournal, sans-serif' }}
+          >
             {isCreateMode ? 'Create/Edit Message' : 'Edit Message'}
           </SheetTitle>
         </SheetHeader>
@@ -1274,7 +1279,7 @@ const CampaignTemplateDrawer: React.FC<CampaignTemplateDrawerProps> = ({
           )}
         </div>
 
-        <SheetFooter className="shrink-0 flex-row gap-3 border-t bg-white px-4 py-4 pb-[calc(1rem+env(safe-area-inset-bottom))] md:px-6 sm:justify-end sm:space-x-0">
+        <SheetFooter className="shrink-0 flex-row gap-3 border-t px-4 py-4 pb-[calc(1rem+env(safe-area-inset-bottom))] md:px-6 sm:justify-end sm:space-x-0">
           <Button
             type="button"
             variant="outline"

--- a/src/components/ViewportHeightProvider.tsx
+++ b/src/components/ViewportHeightProvider.tsx
@@ -9,10 +9,12 @@ export default function ViewportHeightProvider() {
       document.documentElement.style.setProperty('--vh', `${vh}px`);
     }
 
+    const handleOrientationChange = () => setTimeout(setVH, 100);
+
     setVH();
 
     window.addEventListener('resize', setVH);
-    window.addEventListener('orientationchange', () => setTimeout(setVH, 100));
+    window.addEventListener('orientationchange', handleOrientationChange);
     if ('visualViewport' in window) {
       // @ts-ignore
       window.visualViewport.addEventListener('resize', setVH);
@@ -20,7 +22,7 @@ export default function ViewportHeightProvider() {
 
     return () => {
       window.removeEventListener('resize', setVH);
-      window.removeEventListener('orientationchange', () => setTimeout(setVH, 100));
+      window.removeEventListener('orientationchange', handleOrientationChange);
       if ('visualViewport' in window) {
         // @ts-ignore
         window.visualViewport.removeEventListener('resize', setVH);

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -51,14 +51,16 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  overlayClassName?: string
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, overlayClassName, children, ...props }, ref) => (
   <SheetPortal>
-    <SheetOverlay />
+    <SheetOverlay className={overlayClassName} />
     <SheetPrimitive.Content
       ref={ref}
       className={cn(sheetVariants({ side }), className)}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -40,7 +40,7 @@ const sheetVariants = cva(
           "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
         left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import { AppContextProvider } from '../context/AppContext';
 import { SettingsProvider } from '../context/SettingsContext';
 import { AuthProvider } from '../lib/auth-context';
 import MainNav from '../components/MainNav';
+import ViewportHeightProvider from '../components/ViewportHeightProvider';
 import { Toaster } from '@/components/ui/toaster';
 import { Analytics } from '@vercel/analytics/react';
 import type { AppProps } from 'next/app';
@@ -16,6 +17,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
     <AuthProvider>
       <SettingsProvider>
         <AppContextProvider>
+          <ViewportHeightProvider />
           {!hideNav && <MainNav />}
           <Component {...pageProps} />
           <Toaster />
@@ -24,4 +26,4 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       </SettingsProvider>
     </AuthProvider>
   );
-} 
+}

--- a/src/pages/admin/campaigns/[id].tsx
+++ b/src/pages/admin/campaigns/[id].tsx
@@ -1,34 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import {
-  Box,
-  VStack,
-  HStack,
-  Text,
-  Button,
-  Input,
-  Textarea,
-  Select,
-  Switch,
-  Badge,
-  useToast,
-  IconButton,
-  Table,
-  Thead,
-  Tbody,
-  Tr,
-  Th,
-  Td,
-  Divider,
-  Flex,
-  Grid,
-  GridItem,
-} from '@chakra-ui/react';
-import { ArrowBackIcon, EditIcon, DeleteIcon, AddIcon } from '@chakra-ui/icons';
 import { useRouter } from 'next/router';
+import { ArrowLeft, Pencil, Trash2, Plus } from 'lucide-react';
 import { supabase } from '../../../lib/supabase';
 import AdminLayout from '../../../components/layouts/AdminLayout';
 import CampaignTemplateDrawer from '../../../components/CampaignTemplateDrawer';
 import { sortCampaignTemplates } from '../../../utils/campaignSorting';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select } from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/useToast';
 
 interface Campaign {
   id: string;
@@ -79,7 +61,7 @@ export default function CampaignEditPage() {
   const [isTemplateCreateMode, setIsTemplateCreateMode] = useState(false);
   const [editingField, setEditingField] = useState<string | null>(null);
   const [editValue, setEditValue] = useState<string>('');
-  const toast = useToast();
+  const { toast } = useToast();
 
   useEffect(() => {
     if (id) {
@@ -95,23 +77,19 @@ export default function CampaignEditPage() {
 
   const fetchCampaign = async () => {
     try {
-      console.log('Fetching campaign with ID:', id);
       const response = await fetch(`/api/campaigns/${id}`);
-      console.log('Response status:', response.status);
-      
+
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        console.error('Response error data:', errorData);
         throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`);
       }
-      
+
       const data = await response.json();
-      console.log('Campaign data received:', data);
 
       if (!data) {
         throw new Error('Campaign not found');
       }
-      
+
       setCampaign(data);
     } catch (error) {
       console.error('Error fetching campaign:', error);
@@ -120,7 +98,6 @@ export default function CampaignEditPage() {
         description: 'Failed to fetch campaign',
         status: 'error',
         duration: 5000,
-        isClosable: true,
       });
     } finally {
       setLoading(false);
@@ -129,17 +106,15 @@ export default function CampaignEditPage() {
 
   const fetchTemplates = async () => {
     try {
-      console.log('Fetching templates for campaign_id:', campaign?.id);
       const response = await fetch(`/api/campaign-messages?campaign_id=${campaign?.id}`);
       if (!response.ok) {
         throw new Error('Failed to fetch templates');
       }
       const data = await response.json();
-      console.log('All templates fetched:', data);
-      
+
       // Sort templates by proximity to trigger event
       const sortedTemplates = sortCampaignTemplates(data);
-      
+
       setTemplates(sortedTemplates);
     } catch (error) {
       console.error('Error fetching templates:', error);
@@ -148,7 +123,6 @@ export default function CampaignEditPage() {
         description: 'Failed to fetch templates',
         status: 'error',
         duration: 5000,
-        isClosable: true,
       });
     }
   };
@@ -179,7 +153,6 @@ export default function CampaignEditPage() {
         description: 'Campaign updated successfully',
         status: 'success',
         duration: 2000,
-        isClosable: true,
       });
     } catch (error) {
       console.error('Error updating campaign:', error);
@@ -188,7 +161,6 @@ export default function CampaignEditPage() {
         description: 'Failed to update campaign',
         status: 'error',
         duration: 5000,
-        isClosable: true,
       });
     } finally {
       setSaving(false);
@@ -243,7 +215,6 @@ export default function CampaignEditPage() {
         description: 'Template deleted successfully',
         status: 'success',
         duration: 2000,
-        isClosable: true,
       });
     } catch (error) {
       console.error('Error deleting template:', error);
@@ -252,7 +223,6 @@ export default function CampaignEditPage() {
         description: 'Failed to delete template',
         status: 'error',
         duration: 5000,
-        isClosable: true,
       });
     }
   };
@@ -271,7 +241,7 @@ export default function CampaignEditPage() {
         throw new Error('Failed to update template');
       }
 
-      setTemplates(templates.map(t => 
+      setTemplates(templates.map(t =>
         t.id === template.id ? { ...t, is_active: !t.is_active } : t
       ));
 
@@ -280,7 +250,6 @@ export default function CampaignEditPage() {
         description: `Template ${!template.is_active ? 'activated' : 'deactivated'} successfully`,
         status: 'success',
         duration: 2000,
-        isClosable: true,
       });
     } catch (error) {
       console.error('Error updating template:', error);
@@ -289,7 +258,6 @@ export default function CampaignEditPage() {
         description: 'Failed to update template',
         status: 'error',
         duration: 5000,
-        isClosable: true,
       });
     }
   };
@@ -307,7 +275,7 @@ export default function CampaignEditPage() {
       const period = hours >= 12 ? 'PM' : 'AM';
       const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
       const displayTime = `${displayHours}:${minutes.toString().padStart(2, '0')}${period}`;
-      
+
       if (template.specific_date) {
         return `${displayTime} on ${template.specific_date}`;
       } else {
@@ -319,7 +287,7 @@ export default function CampaignEditPage() {
       const period = hours >= 12 ? 'PM' : 'AM';
       const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
       const displayTime = `${displayHours}:${minutes.toString().padStart(2, '0')}${period}`;
-      
+
       if (template.recurring_type === 'daily') {
         return `Daily at ${displayTime}`;
       } else if (template.recurring_type === 'weekly') {
@@ -340,11 +308,11 @@ export default function CampaignEditPage() {
       const period = hours >= 12 ? 'PM' : 'AM';
       const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
       const displayTime = `${displayHours}:${minutes.toString().padStart(2, '0')}${period}`;
-      
+
       const quantity = template.relative_quantity || 0;
       const unit = template.relative_unit || 'day';
       const proximity = template.relative_proximity || 'after';
-      
+
       if (quantity === 0) {
         return `${displayTime} on trigger date`;
       } else {
@@ -371,14 +339,9 @@ export default function CampaignEditPage() {
   if (loading) {
     return (
       <AdminLayout>
-        <Box
-          px={10}
-          py={12}
-          style={{ backgroundImage: 'linear-gradient(to bottom right, #ECEDE8, #FFFFFF)', backgroundAttachment: 'fixed' }}
-          minH="100vh"
-        >
-          <Text>Loading campaign...</Text>
-        </Box>
+        <div className="min-h-screen bg-gradient-to-br from-[#ECEDE8] to-white bg-fixed px-4 py-8 md:px-10 md:py-12">
+          <p>Loading campaign...</p>
+        </div>
       </AdminLayout>
     );
   }
@@ -386,231 +349,148 @@ export default function CampaignEditPage() {
   if (!campaign) {
     return (
       <AdminLayout>
-        <Box
-          px={10}
-          py={12}
-          style={{ backgroundImage: 'linear-gradient(to bottom right, #ECEDE8, #FFFFFF)', backgroundAttachment: 'fixed' }}
-          minH="100vh"
-        >
-          <Text>Campaign not found</Text>
-        </Box>
+        <div className="min-h-screen bg-gradient-to-br from-[#ECEDE8] to-white bg-fixed px-4 py-8 md:px-10 md:py-12">
+          <p>Campaign not found</p>
+        </div>
       </AdminLayout>
     );
   }
 
   return (
     <AdminLayout>
-      <Box
-        px={10}
-        py={12}
-        bg="white"
-        minH="100vh"
-      >
-        <VStack spacing={8} align="stretch">
+      <div className="min-h-screen bg-white px-4 py-8 md:px-10 md:py-12">
+        <div className="flex flex-col gap-8">
           {/* Header */}
-          <HStack justify="space-between" align="center">
-            <HStack spacing={4}>
-              <IconButton
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="flex items-center gap-4">
+              <button
                 onClick={() => router.push('/admin/communication')}
-                icon={<ArrowBackIcon />}
-                variant="ghost"
-                color="#a59480"
-                _hover={{ bg: '#ecede8' }}
                 aria-label="Back to campaigns"
-              />
-              <Text
-                fontSize="3xl"
-                fontWeight="bold"
-                color="#353535"
-                fontFamily="'IvyJournal', serif"
-                letterSpacing="tight"
-                mb={4}
+                className="flex h-11 w-11 items-center justify-center rounded-md text-[#a59480] hover:bg-[#ecede8]"
               >
+                <ArrowLeft className="h-5 w-5" />
+              </button>
+              <h1 className="font-ivyjournal text-2xl font-bold tracking-tight text-[#353535] md:text-3xl">
                 Edit Campaign
-              </Text>
-            </HStack>
+              </h1>
+            </div>
             <Button
               onClick={handleCreateMessage}
-              leftIcon={<AddIcon />}
-              colorScheme="green"
-              size="lg"
-              px={8}
-              py={6}
-              fontSize="lg"
-              fontWeight="bold"
-              fontFamily="'Montserrat', sans-serif"
-              bg="#a59480"
-              color="white"
-              _hover={{
-                bg: '#8a7a66',
-                transform: 'translateY(-2px)',
-                boxShadow: '0 8px 25px rgba(165, 148, 128, 0.3)',
-              }}
-              _active={{
-                bg: '#7a6a56',
-                transform: 'translateY(0)',
-              }}
-              borderRadius="xl"
-              boxShadow="0 4px 15px rgba(165, 148, 128, 0.2)"
+              className="min-h-[44px] w-full rounded-xl bg-[#a59480] font-montserrat text-white shadow-[0_4px_15px_rgba(165,148,128,0.2)] hover:bg-[#8a7a66] md:w-auto"
             >
+              <Plus className="mr-2 h-4 w-4" />
               Create New Message
             </Button>
-          </HStack>
+          </div>
 
           {/* Condensed Campaign Details */}
-          <Box
-            borderRadius="xl"
-            overflow="hidden"
-            boxShadow="0 10px 30px rgba(0,0,0,0.15)"
-            w="100%"
-            transition="all 0.3s ease"
-            _hover={{
-              transform: 'translateY(-4px)',
-              boxShadow: '0 15px 40px rgba(0,0,0,0.2)',
-            }}
-          >
-            <Box bg="#a59480" px={6} py={4}>
-              <Text fontSize="2xl" letterSpacing="wide" fontFamily="'Montserrat', sans-serif" fontWeight="bold" color="white">
-                Campaign Details
-              </Text>
-            </Box>
-            <Box bg="white" px={6} py={6}>
-              <VStack spacing={4} align="stretch">
-                <HStack justify="space-between" align="center">
-                  <HStack spacing={2}>
-                    {saving && (
-                      <Badge colorScheme="blue" fontFamily="'Montserrat', sans-serif">
-                        Saving...
-                      </Badge>
-                    )}
-                  </HStack>
-                </HStack>
-                <Grid templateColumns="repeat(2, 1fr)" gap={6}>
+          <div className="w-full overflow-hidden rounded-xl shadow-[0_10px_30px_rgba(0,0,0,0.15)]">
+            <div className="bg-[#a59480] px-6 py-4">
+              <p className="font-montserrat text-2xl font-bold tracking-wide text-white">Campaign Details</p>
+            </div>
+            <div className="bg-white px-6 py-6">
+              <div className="flex flex-col gap-4">
+                {saving && (
+                  <div>
+                    <Badge className="bg-blue-100 text-blue-800">Saving...</Badge>
+                  </div>
+                )}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   {/* Campaign ID */}
-                  <GridItem>
-                    <Text fontSize="sm" color="#666" fontFamily="'Montserrat', sans-serif" mb={1}>
-                      Campaign ID
-                    </Text>
-                    <Text fontSize="md" fontFamily="'Montserrat', sans-serif" fontWeight="bold" color="#353535">
-                      {campaign.id}
-                    </Text>
-                  </GridItem>
+                  <div>
+                    <p className="mb-1 font-montserrat text-sm text-[#666]">Campaign ID</p>
+                    <p className="break-all font-montserrat font-bold text-[#353535]">{campaign.id}</p>
+                  </div>
                   {/* Status */}
-                  <GridItem >
-                    <Text fontSize="sm" color="#666" fontFamily="'Montserrat', sans-serif" mb={1}>
-                      Status
-                    </Text>
+                  <div>
+                    <p className="mb-1 font-montserrat text-sm text-[#666]">Status</p>
                     <Button
                       size="sm"
-                      colorScheme={campaign.is_active ? 'green' : 'red'}
                       variant="outline"
                       onClick={() => handleCampaignUpdate('is_active', !campaign.is_active)}
-                      isDisabled={saving}
-                      fontFamily="'Montserrat', sans-serif"
-                      fontWeight="bold"
-                      _hover={{
-                        transform: 'translateY(-1px)',
-                        boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-                      }}
+                      disabled={saving}
+                      className={campaign.is_active
+                        ? 'border-green-600 text-green-700 hover:bg-green-600 hover:text-white'
+                        : 'border-red-600 text-red-700 hover:bg-red-600 hover:text-white'}
                     >
                       {campaign.is_active ? 'Active' : 'Inactive'}
                     </Button>
-                  </GridItem>
+                  </div>
                   {/* Campaign Name */}
-                  <GridItem colSpan={2}>
-                    <Text fontSize="sm" color="#666" fontFamily="'Montserrat', sans-serif" mb={1}>
-                      Campaign Name *
-                    </Text>
+                  <div className="md:col-span-2">
+                    <p className="mb-1 font-montserrat text-sm text-[#666]">Campaign Name *</p>
                     {editingField === 'name' ? (
-                      <HStack>
+                      <div className="flex flex-col gap-2 md:flex-row md:items-center">
                         <Input
                           value={editValue}
                           onChange={(e) => setEditValue(e.target.value)}
-                          bg="white"
-                          borderColor="#a59480"
-                          _focus={{ borderColor: '#8a7a66', boxShadow: '0 0 0 1px #8a7a66' }}
-                          fontFamily="'Montserrat', sans-serif"
                           placeholder="Enter campaign name"
-                          _placeholder={{ color: '#999' }}
+                          className="flex-1"
                         />
-                        <Button size="sm" colorScheme="green" onClick={saveEdit}>
-                          Save
-                        </Button>
-                        <Button size="sm" variant="outline" onClick={cancelEdit}>
-                          Cancel
-                        </Button>
-                      </HStack>
+                        <div className="flex gap-2">
+                          <Button size="sm" onClick={saveEdit} className="min-h-[44px] flex-1 bg-green-600 text-white hover:bg-green-700 md:flex-none">
+                            Save
+                          </Button>
+                          <Button size="sm" variant="outline" onClick={cancelEdit} className="min-h-[44px] flex-1 md:flex-none">
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
                     ) : (
-                      <HStack justify="space-between" >
-                        <Text fontSize="lg" fontFamily="'Montserrat', sans-serif" fontWeight="bold" color="#353535">
-                          {campaign.name}
-                        </Text>
-                        <IconButton
-                          size="sm"
-                          icon={<EditIcon />}
-                          variant="ghost"
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="font-montserrat text-lg font-bold text-[#353535]">{campaign.name}</p>
+                        <button
                           onClick={() => startEditing('name', campaign.name)}
                           aria-label="Edit campaign name"
-                        />
-                      </HStack>
+                          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-[#a59480] hover:bg-[#ecede8]"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </button>
+                      </div>
                     )}
-                  </GridItem>
+                  </div>
                   {/* Description */}
-                  <GridItem colSpan={2}>
-                    <Text fontSize="sm" color="#666" fontFamily="'Montserrat', sans-serif" mb={1}>
-                      Description
-                    </Text>
+                  <div className="md:col-span-2">
+                    <p className="mb-1 font-montserrat text-sm text-[#666]">Description</p>
                     {editingField === 'description' ? (
-                      <VStack align="stretch">
+                      <div className="flex flex-col gap-2">
                         <Textarea
                           value={editValue}
                           onChange={(e) => setEditValue(e.target.value)}
-                          bg="white"
-                          borderColor="#a59480"
-                          _focus={{ borderColor: '#8a7a66', boxShadow: '0 0 0 1px #8a7a66' }}
-                          fontFamily="'Montserrat', sans-serif"
                           rows={3}
                           placeholder="Enter campaign description"
-                          _placeholder={{ color: '#999' }}
                         />
-                        <HStack>
-                          <Button size="sm" colorScheme="green" onClick={saveEdit}>
+                        <div className="flex gap-2">
+                          <Button size="sm" onClick={saveEdit} className="min-h-[44px] flex-1 bg-green-600 text-white hover:bg-green-700 md:flex-none">
                             Save
                           </Button>
-                          <Button size="sm" variant="outline" onClick={cancelEdit}>
+                          <Button size="sm" variant="outline" onClick={cancelEdit} className="min-h-[44px] flex-1 md:flex-none">
                             Cancel
                           </Button>
-                        </HStack>
-                      </VStack>
+                        </div>
+                      </div>
                     ) : (
-                      <HStack justify="space-between">
-                        <Text fontSize="md" fontFamily="'Montserrat', sans-serif" color="#353535">
-                          {campaign.description || 'No description'}
-                        </Text>
-                        <IconButton
-                          size="sm"
-                          icon={<EditIcon />}
-                          variant="ghost"
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="font-montserrat text-[#353535]">{campaign.description || 'No description'}</p>
+                        <button
                           onClick={() => startEditing('description', campaign.description || '')}
                           aria-label="Edit description"
-                        />
-                      </HStack>
+                          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-[#a59480] hover:bg-[#ecede8]"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </button>
+                      </div>
                     )}
-                  </GridItem>
+                  </div>
                   {/* Trigger Type */}
-                  <GridItem colSpan={2}>
-                    <Text fontSize="sm" color="#666" fontFamily="'Montserrat', sans-serif" mb={1}>
-                      Trigger Type *
-                    </Text>
+                  <div className="md:col-span-2">
+                    <p className="mb-1 font-montserrat text-sm text-[#666]">Trigger Type *</p>
                     {editingField === 'trigger_type' ? (
-                      <HStack>
+                      <div className="flex flex-col gap-2 md:flex-row md:items-center">
                         <Select
                           value={editValue}
                           onChange={(e) => setEditValue(e.target.value)}
-                          bg="white"
-                          borderColor="#a59480"
-                          _focus={{ borderColor: '#8a7a66', boxShadow: '0 0 0 1px #8a7a66' }}
-                          fontFamily="'Montserrat', sans-serif"
+                          className="flex-1"
                         >
                           <option value="all_members">All Members</option>
                           <option value="member_birthday">Member Birthday</option>
@@ -623,124 +503,162 @@ export default function CampaignEditPage() {
                           <option value="reservation_range">Reservation Range</option>
                           <option value="reservation_time">Reservation Time</option>
                         </Select>
-                        <Button size="sm" colorScheme="green" onClick={saveEdit}>
-                          Save
-                        </Button>
-                        <Button size="sm" variant="outline" onClick={cancelEdit}>
-                          Cancel
-                        </Button>
-                      </HStack>
+                        <div className="flex gap-2">
+                          <Button size="sm" onClick={saveEdit} className="min-h-[44px] flex-1 bg-green-600 text-white hover:bg-green-700 md:flex-none">
+                            Save
+                          </Button>
+                          <Button size="sm" variant="outline" onClick={cancelEdit} className="min-h-[44px] flex-1 md:flex-none">
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
                     ) : (
-                      <HStack justify="space-between">
-                        <Text fontSize="md" fontFamily="'Montserrat', sans-serif" fontWeight="bold" color="#353535">
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="font-montserrat font-bold text-[#353535]">
                           {campaign.trigger_type.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase())}
-                        </Text>
-                        <IconButton
-                          size="sm"
-                          icon={<EditIcon />}
-                          variant="ghost"
+                        </p>
+                        <button
                           onClick={() => startEditing('trigger_type', campaign.trigger_type)}
                           aria-label="Edit trigger type"
-                        />
-                      </HStack>
+                          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-[#a59480] hover:bg-[#ecede8]"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </button>
+                      </div>
                     )}
-                  </GridItem>
-                </Grid>
-              </VStack>
-            </Box>
-          </Box>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 
           {/* Message Templates */}
-          <Box
-            borderRadius="xl"
-            overflow="hidden"
-            boxShadow="0 10px 30px rgba(0,0,0,0.15)"
-            w="100%"
-          >
-            <Box bg="#a59480" px={6} py={4}>
-              <Text fontSize="2xl" letterSpacing="wide" fontFamily="'Montserrat', sans-serif" fontWeight="bold" color="white">
+          <div className="w-full overflow-hidden rounded-xl shadow-[0_10px_30px_rgba(0,0,0,0.15)]">
+            <div className="bg-[#a59480] px-6 py-4">
+              <p className="font-montserrat text-2xl font-bold tracking-wide text-white">
                 Message Templates ({templates.length})
-              </Text>
-            </Box>
-            <Box bg="white" px={6} py={6} overflowX="auto">
+              </p>
+            </div>
+            <div className="bg-white px-4 py-6 md:px-6">
               {templates.length === 0 ? (
-                <Box textAlign="center" py={12}>
-                  <Text fontSize="xl" color="#666" fontFamily="'Montserrat', sans-serif" mb={4}>
-                    No message templates yet
-                  </Text>
-                  <Text fontSize="md" color="#888" fontFamily="'Montserrat', sans-serif">
+                <div className="py-12 text-center">
+                  <p className="mb-4 font-montserrat text-xl text-[#666]">No message templates yet</p>
+                  <p className="font-montserrat text-[#888]">
                     Create your first message template to start sending messages
-                  </Text>
-                </Box>
+                  </p>
+                </div>
               ) : (
-                <Table variant="striped" colorScheme="gray" size="lg">
-                  <Thead>
-                    <Tr >
-                      <Th fontFamily="'Montserrat', sans-serif" fontWeight="bold" padding={20} fontSize="lg" py={14} width="15%">Template Name</Th>
-                      <Th fontFamily="'Montserrat', sans-serif" fontWeight="bold" padding={20} fontSize="lg" py={14} width="25%">Description</Th>
-                      <Th fontFamily="'Montserrat', sans-serif" fontWeight="bold" padding={20} fontSize="lg" py={14} width="25%">Timing</Th>
-                      <Th fontFamily="'Montserrat', sans-serif" fontWeight="bold" padding={20} fontSize="lg" py={14} width="15%">Recipient</Th>
-                      <Th fontFamily="'Montserrat', sans-serif" fontWeight="bold" padding={20} fontSize="lg" py={14} width="10%">Status</Th>
-                      <Th fontFamily="'Montserrat', sans-serif" fontWeight="bold" padding={20} fontSize="lg" py={14} width="10%">Actions</Th>
-                    </Tr>
-                  </Thead>
-                  <Tbody>
+                <>
+                  {/* Desktop table */}
+                  <div className="hidden overflow-x-auto md:block">
+                    <table className="w-full border-collapse">
+                      <thead>
+                        <tr className="bg-[#f7f7f5]">
+                          <th className="p-3 text-left font-montserrat font-bold text-[#353535]">Template Name</th>
+                          <th className="p-3 text-left font-montserrat font-bold text-[#353535]">Description</th>
+                          <th className="p-3 text-left font-montserrat font-bold text-[#353535]">Timing</th>
+                          <th className="p-3 text-left font-montserrat font-bold text-[#353535]">Recipient</th>
+                          <th className="p-3 text-left font-montserrat font-bold text-[#353535]">Status</th>
+                          <th className="p-3 text-left font-montserrat font-bold text-[#353535]">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {templates.map((template) => (
+                          <tr key={template.id} className="border-b border-[#ececec] hover:bg-[#f0f0f0]">
+                            <td className="p-3 align-top font-montserrat font-bold text-[#353535]">{template.name}</td>
+                            <td className="max-w-[300px] p-3 align-top font-montserrat text-[#353535]">
+                              <p className="line-clamp-3 break-words">{template.description || '-'}</p>
+                            </td>
+                            <td className="max-w-[300px] p-3 align-top font-montserrat text-[#353535]">
+                              <p className="line-clamp-2 break-words">{formatTiming(template)}</p>
+                            </td>
+                            <td className="p-3 align-top font-montserrat text-[#353535]">{formatRecipient(template)}</td>
+                            <td className="p-3 align-top">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => handleToggleTemplateActive(template)}
+                                className={template.is_active
+                                  ? 'border-green-600 text-green-700 hover:bg-green-600 hover:text-white'
+                                  : 'border-red-600 text-red-700 hover:bg-red-600 hover:text-white'}
+                              >
+                                {template.is_active ? 'Active' : 'Inactive'}
+                              </Button>
+                            </td>
+                            <td className="p-3 align-top">
+                              <div className="flex gap-2">
+                                <button
+                                  aria-label="Edit template"
+                                  onClick={() => handleEditTemplate(template)}
+                                  className="flex h-11 w-11 items-center justify-center rounded-md bg-blue-600 text-white hover:bg-blue-700"
+                                >
+                                  <Pencil className="h-4 w-4" />
+                                </button>
+                                <button
+                                  aria-label="Delete template"
+                                  onClick={() => handleDeleteTemplate(template.id)}
+                                  className="flex h-11 w-11 items-center justify-center rounded-md bg-red-600 text-white hover:bg-red-700"
+                                >
+                                  <Trash2 className="h-4 w-4" />
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {/* Mobile cards */}
+                  <div className="flex flex-col gap-3 md:hidden">
                     {templates.map((template) => (
-                        <Tr key={template.id} _hover={{ bg: '#f0f0f0' }}>
-                          <Td fontFamily="'Montserrat', sans-serif" fontWeight="bold" fontSize="md" py={6} px={4}>
-                            {template.name}
-                          </Td>
-                          <Td fontFamily="'Montserrat', sans-serif" fontSize="md" py={6} px={4} maxW="300px">
-                            <Text noOfLines={3} wordBreak="break-word">
-                              {template.description || '-'}
-                            </Text>
-                          </Td>
-                          <Td fontFamily="'Montserrat', sans-serif" fontSize="md" py={6} px={4} maxW="300px">
-                            <Text noOfLines={2} wordBreak="break-word">
-                              {formatTiming(template)}
-                            </Text>
-                          </Td>
-                          <Td fontFamily="'Montserrat', sans-serif" fontSize="md" py={6} px={4}>
-                            {formatRecipient(template)}
-                          </Td>
-                          <Td py={6} px={4}>
-                            <Button
-                              size="sm"
-                              colorScheme={template.is_active ? 'green' : 'red'}
-                              variant="outline"
-                              onClick={() => handleToggleTemplateActive(template)}
-                              fontFamily="'Montserrat', sans-serif"
-                              fontWeight="bold"
+                      <div key={template.id} className="rounded-2xl border border-[#ececec] bg-white p-4 shadow-sm">
+                        <div className="mb-2 flex items-start justify-between gap-2">
+                          <p className="font-montserrat font-bold text-[#353535]">{template.name}</p>
+                          <div className="flex gap-1">
+                            <button
+                              aria-label="Edit template"
+                              onClick={() => handleEditTemplate(template)}
+                              className="flex h-11 w-11 items-center justify-center rounded-md bg-blue-600 text-white hover:bg-blue-700"
                             >
-                              {template.is_active ? 'Active' : 'Inactive'}
-                            </Button>
-                          </Td>
-                          <Td py={6} px={4}>
-                            <HStack spacing={2}>
-                              <IconButton 
-                                aria-label="Edit template" 
-                                icon={<EditIcon />} 
-                                size="md" 
-                                colorScheme="blue" 
-                                onClick={() => handleEditTemplate(template)}
-                              />
-                              <IconButton 
-                                aria-label="Delete template" 
-                                icon={<DeleteIcon />} 
-                                size="md" 
-                                colorScheme="red" 
-                                onClick={() => handleDeleteTemplate(template.id)}
-                              />
-                            </HStack>
-                          </Td>
-                        </Tr>
-                      ))}
-                  </Tbody>
-                </Table>
+                              <Pencil className="h-4 w-4" />
+                            </button>
+                            <button
+                              aria-label="Delete template"
+                              onClick={() => handleDeleteTemplate(template.id)}
+                              className="flex h-11 w-11 items-center justify-center rounded-md bg-red-600 text-white hover:bg-red-700"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </button>
+                          </div>
+                        </div>
+                        {template.description && (
+                          <p className="mb-2 font-montserrat text-sm text-[#666]">{template.description}</p>
+                        )}
+                        <div className="flex flex-col gap-1 font-montserrat text-sm text-[#353535]">
+                          <p><span className="text-[#888]">Timing:</span> {formatTiming(template)}</p>
+                          <p><span className="text-[#888]">Recipient:</span> {formatRecipient(template)}</p>
+                        </div>
+                        <div className="mt-3">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handleToggleTemplateActive(template)}
+                            className={template.is_active
+                              ? 'min-h-[44px] border-green-600 text-green-700 hover:bg-green-600 hover:text-white'
+                              : 'min-h-[44px] border-red-600 text-red-700 hover:bg-red-600 hover:text-white'}
+                          >
+                            {template.is_active ? 'Active' : 'Inactive'}
+                          </Button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </>
               )}
-            </Box>
-          </Box>
-        </VStack>
+            </div>
+          </div>
+        </div>
 
         {/* Template Drawer */}
         <CampaignTemplateDrawer
@@ -752,7 +670,7 @@ export default function CampaignEditPage() {
           campaignId={campaign.id}
           campaignTriggerType={campaign?.trigger_type}
         />
-      </Box>
+      </div>
     </AdminLayout>
   );
-} 
+}


### PR DESCRIPTION
Closes #50.

Ports CampaignDrawer, CampaignTemplateDrawer, and campaigns/[id].tsx off Chakra UI onto shadcn/ui primitives (Sheet, form controls, useToast) for full mobile parity. Fixes the sheet.tsx border-r/border-l bug on the right variant and adds the missing explicit @radix-ui/react-dialog dependency. Zero Chakra imports remain in the three files.

No merge — awaiting manual review of the Vercel preview.